### PR TITLE
Configure and enable rules using environment variables

### DIFF
--- a/apps/onboarding/src/app.module.ts
+++ b/apps/onboarding/src/app.module.ts
@@ -8,6 +8,7 @@ import { AppService } from './app.service'
 import appConfig from './config/app.config'
 import databaseConfig from './config/database.config'
 import relayerConfig from './config/relayer.config'
+import rulesConfig from './config/rules.config'
 import thirdPartyConfig from './config/third-party.config'
 import { GatewayModule } from './gateway/gateway.module'
 import { RelayerProxyService } from './relayer_proxy.service'
@@ -18,7 +19,7 @@ import { SessionModule } from './session/session.module'
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [relayerConfig, appConfig, thirdPartyConfig, databaseConfig],
+      load: [relayerConfig, appConfig, thirdPartyConfig, databaseConfig, rulesConfig],
       envFilePath: ['apps/onboarding/.env.local']
     }),
     LoggerModule.forRootAsync({

--- a/apps/onboarding/src/config/rules.config.ts
+++ b/apps/onboarding/src/config/rules.config.ts
@@ -1,0 +1,21 @@
+import { registerAs } from '@nestjs/config'
+
+function getConfig(config: string | undefined) {
+  try {
+    return JSON.parse(config)
+  // tslint:disable-next-line
+  } catch { }
+}
+
+export default registerAs('rules', () => ({
+  enabled: {
+    DAILY_CAP: process.env.RULE_DAILY_CAP_ENABLED === 'true',
+    CAPTCHA: process.env.RULE_CAPTCHA_ENABLED === 'true',
+    DEVICE_ATTESTATION: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
+  },
+  configs: {
+    DAILY_CAP: getConfig(process.env.RULE_DAILY_CAP_CONFIG),
+    CAPTCHA: getConfig(process.env.RULE_CAPTCHA_CONFIG),
+    DEVICE_ATTESTATION: getConfig(process.env.RULE_DEVICE_ATTESTATION_CONFIG),
+  },
+}))

--- a/apps/onboarding/src/config/rules.config.ts
+++ b/apps/onboarding/src/config/rules.config.ts
@@ -1,11 +1,13 @@
 import { registerAs } from '@nestjs/config'
 import { RuleID } from 'apps/onboarding/src/gateway/rules/rule'
 
+const isTrue = (content: string) => String(content).toLowerCase() === 'true'
+
 export default registerAs('rules', (): RulesConfig => ({
   enabled: {
-    [RuleID.DailyCap]: process.env.RULE_DAILY_CAP_ENABLED === 'true',
-    [RuleID.Captcha]: process.env.RULE_CAPTCHA_ENABLED === 'true',
-    [RuleID.DeviceAttestation]: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
+    [RuleID.DailyCap]: isTrue(process.env.RULE_DAILY_CAP_ENABLED),
+    [RuleID.Captcha]: isTrue(process.env.RULE_CAPTCHA_ENABLED),
+    [RuleID.DeviceAttestation]: isTrue(process.env.RULE_DEVICE_ATTESTATION_ENABLED),
   },
   configs: {
     [RuleID.DailyCap]: process.env.RULE_DAILY_CAP_CONFIG,

--- a/apps/onboarding/src/config/rules.config.ts
+++ b/apps/onboarding/src/config/rules.config.ts
@@ -8,9 +8,9 @@ export default registerAs('rules', (): RulesConfig => ({
     [RuleID.DeviceAttestation]: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
   },
   configs: {
-    DAILY_CAP: process.env.RULE_DAILY_CAP_CONFIG,
-    CAPTCHA: process.env.RULE_CAPTCHA_CONFIG,
-    DEVICE_ATTESTATION: process.env.RULE_DEVICE_ATTESTATION_CONFIG,
+    [RuleID.DailyCap]: process.env.RULE_DAILY_CAP_CONFIG,
+    [RuleID.Captcha]: process.env.RULE_CAPTCHA_CONFIG,
+    [RuleID.DeviceAttestation]: process.env.RULE_DEVICE_ATTESTATION_CONFIG,
   },
 }))
 

--- a/apps/onboarding/src/config/rules.config.ts
+++ b/apps/onboarding/src/config/rules.config.ts
@@ -1,13 +1,6 @@
 import { registerAs } from '@nestjs/config'
 import { RuleID } from 'apps/onboarding/src/gateway/rules/rule'
 
-function getConfig(config: string | undefined) {
-  try {
-    return JSON.parse(config)
-  // tslint:disable-next-line
-  } catch { }
-}
-
 export default registerAs('rules', (): RulesConfig => ({
   enabled: {
     [RuleID.DailyCap]: process.env.RULE_DAILY_CAP_ENABLED === 'true',
@@ -15,9 +8,9 @@ export default registerAs('rules', (): RulesConfig => ({
     [RuleID.DeviceAttestation]: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
   },
   configs: {
-    [RuleID.DailyCap]: getConfig(process.env.RULE_DAILY_CAP_CONFIG),
-    [RuleID.Captcha]: getConfig(process.env.RULE_CAPTCHA_CONFIG),
-    [RuleID.DeviceAttestation]: getConfig(process.env.RULE_DEVICE_ATTESTATION_CONFIG),
+    DAILY_CAP: process.env.RULE_DAILY_CAP_CONFIG,
+    CAPTCHA: process.env.RULE_CAPTCHA_CONFIG,
+    DEVICE_ATTESTATION: process.env.RULE_DEVICE_ATTESTATION_CONFIG,
   },
 }))
 

--- a/apps/onboarding/src/config/rules.config.ts
+++ b/apps/onboarding/src/config/rules.config.ts
@@ -1,4 +1,5 @@
 import { registerAs } from '@nestjs/config'
+import { RuleID } from 'apps/onboarding/src/gateway/rules/rule'
 
 function getConfig(config: string | undefined) {
   try {
@@ -7,15 +8,20 @@ function getConfig(config: string | undefined) {
   } catch { }
 }
 
-export default registerAs('rules', () => ({
+export default registerAs('rules', (): RulesConfig => ({
   enabled: {
-    DAILY_CAP: process.env.RULE_DAILY_CAP_ENABLED === 'true',
-    CAPTCHA: process.env.RULE_CAPTCHA_ENABLED === 'true',
-    DEVICE_ATTESTATION: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
+    [RuleID.DailyCap]: process.env.RULE_DAILY_CAP_ENABLED === 'true',
+    [RuleID.Captcha]: process.env.RULE_CAPTCHA_ENABLED === 'true',
+    [RuleID.DeviceAttestation]: process.env.RULE_DEVICE_ATTESTATION_ENABLED === 'true',
   },
   configs: {
-    DAILY_CAP: getConfig(process.env.RULE_DAILY_CAP_CONFIG),
-    CAPTCHA: getConfig(process.env.RULE_CAPTCHA_CONFIG),
-    DEVICE_ATTESTATION: getConfig(process.env.RULE_DEVICE_ATTESTATION_CONFIG),
+    [RuleID.DailyCap]: getConfig(process.env.RULE_DAILY_CAP_CONFIG),
+    [RuleID.Captcha]: getConfig(process.env.RULE_CAPTCHA_CONFIG),
+    [RuleID.DeviceAttestation]: getConfig(process.env.RULE_DEVICE_ATTESTATION_CONFIG),
   },
 }))
+
+export interface RulesConfig {
+  enabled: Partial<Record<RuleID, boolean>>,
+  configs: Partial<Record<RuleID, any>>
+}

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -1,12 +1,16 @@
 import { Test, TestingModule } from '@nestjs/testing'
+import { HttpModule, HttpService } from '@nestjs/common'
 import { GatewayService } from './gateway.service'
+import { AppModule } from '../app.module'
+import { CaptchaService } from './captcha/captcha.service'
 
 describe('GatewayService', () => {
   let service: GatewayService
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [GatewayService]
+      imports: [HttpModule, AppModule],
+      providers: [GatewayService, CaptchaService]
     }).compile()
 
     service = module.get<GatewayService>(GatewayService)

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -19,4 +19,24 @@ describe('GatewayService', () => {
   it('should be defined', () => {
     expect(service).toBeDefined()
   })
+
+  it('should enable the rules depending on env variables', async () => {
+    process.env.RULE_DAILY_CAP_ENABLED = ''
+    await service.onModuleInit()
+    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: false}))
+
+    process.env.RULE_DAILY_CAP_ENABLED = 'true'
+    await service.onModuleInit()
+    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
+  })
+
+  it('should set the rules config depending on env variables', async () => {
+    process.env.RULE_CAPTCHA_CONFIG = ''
+    await service.onModuleInit()
+    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: null}))
+
+    process.env.RULE_CAPTCHA_CONFIG = '{"test": true}'
+    await service.onModuleInit()
+    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
+  })
 })

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -5,65 +5,141 @@ import { DeviceCheckService } from 'apps/onboarding/src/gateway/device-check/dev
 import { RuleID } from 'apps/onboarding/src/gateway/rules/rule';
 import { SafetyNetService } from 'apps/onboarding/src/gateway/safety-net/safety-net.service';
 import appConfig from 'apps/relayer/src/config/app.config';
-import rulesConfig from '../config/rules.config'
+import rulesConfig, { RulesConfig } from '../config/rules.config'
 import thirdPartyConfig from '../config/third-party.config'
 import { CaptchaService } from './captcha/captcha.service'
 import { GatewayService } from './gateway.service'
 
 describe('GatewayService', () => {
 
-  const buildTestingModule = async (): Promise<TestingModule> => {
-    return Test.createTestingModule({
-      imports: [
-        HttpModule,
-        ConfigModule.forRoot({
-          load: [thirdPartyConfig, rulesConfig],
-        })
-      ],
-      providers: [
-        GatewayService,
-        CaptchaService,
-        DeviceCheckService,
-        SafetyNetService,
-      ]
-    }).compile()
-  }
+  describe("by changing the env", () => {
+    const buildTestingModule = async (): Promise<TestingModule> => {
+      return Test.createTestingModule({
+        imports: [
+          HttpModule,
+          ConfigModule.forRoot({
+            load: [thirdPartyConfig, rulesConfig],
+          })
+        ],
+        providers: [
+          GatewayService,
+          CaptchaService,
+          DeviceCheckService,
+          SafetyNetService,
+        ]
+      }).compile()
+    }
 
-  it('should be defined', async () => {
-    const module = await buildTestingModule()
-    const service = module.get<GatewayService>(GatewayService)
-    expect(service).toBeDefined()
+    it('should be defined', async () => {
+      const module = await buildTestingModule()
+      const service = module.get<GatewayService>(GatewayService)
+      expect(service).toBeDefined()
+    })
+
+    it('should disable the rules depending on env variables when empty', async () => {
+      process.env.RULE_DAILY_CAP_ENABLED = ''
+      const module = await buildTestingModule()
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleEnabled).toEqual(expect.objectContaining({ DAILY_CAP: false }))
+    })
+
+    it('should enable the rules depending on env variables when true', async () => {
+      process.env.RULE_DAILY_CAP_ENABLED = 'true'
+      const module = await buildTestingModule()
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
+    })
+
+    it('should set the rules config depending on env variables when empty', async () => {
+      process.env.RULE_CAPTCHA_CONFIG = ''
+      const module = await buildTestingModule()
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({ CAPTCHA: null }))
+    })
+
+    it('should set the rules config depending on env variables when valid', async () => {
+      process.env.RULE_CAPTCHA_CONFIG = '{"test": true}'
+      const module = await buildTestingModule()
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
+    })
   })
 
-  it('should disable the rules depending on env variables when empty', async () => {
-    process.env.RULE_DAILY_CAP_ENABLED = ''
-    const module = await buildTestingModule()
-    const service = module.get<GatewayService>(GatewayService)
-    await service.onModuleInit()
-    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({ DAILY_CAP: false }))
+  describe("by changing the provider config", () => {
+    const buildTestingModuleForConfig = async (config: RulesConfig): Promise<TestingModule> => {
+      return Test.createTestingModule({
+        imports: [
+          HttpModule,
+          ConfigModule.forRoot({
+            load: [thirdPartyConfig, rulesConfig],
+          })
+        ],
+        providers: [
+          GatewayService,
+          CaptchaService,
+          DeviceCheckService,
+          SafetyNetService,
+        ]
+      }).overrideProvider(rulesConfig.KEY).useValue(config).compile()
+    }
+
+    it('should be defined', async () => {
+      const module = await buildTestingModuleForConfig({enabled: {}, configs: {}})
+      const service = module.get<GatewayService>(GatewayService)
+      expect(service).toBeDefined()
+    })
+
+    it('should disable the rules depending on env variables when empty', async () => {
+      const module = await buildTestingModuleForConfig({
+        configs: {},
+        enabled: {
+          [RuleID.DailyCap]: false
+        }
+      })
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleEnabled).toEqual(expect.objectContaining({ DAILY_CAP: false }))
+    })
+
+    it('should enable the rules depending on env variables when true', async () => {
+      const module = await buildTestingModuleForConfig({
+        configs: {},
+        enabled: {
+          [RuleID.DailyCap]: true
+        }
+      })
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
+    })
+
+    it('should set the rules config depending on env variables when empty', async () => {
+      const module = await buildTestingModuleForConfig({
+        enabled: {},
+        configs: {
+          [RuleID.Captcha]: null
+        }
+      })
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({ CAPTCHA: null }))
+    })
+
+    it('should set the rules config depending on env variables when valid', async () => {
+      const module = await buildTestingModuleForConfig({
+        enabled: {},
+        configs: {
+          [RuleID.Captcha]: {test: true}
+        }
+      })
+      const service = module.get<GatewayService>(GatewayService)
+      await service.onModuleInit()
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
+    })
   })
 
-  it('should enable the rules depending on env variables when true', async () => {
-    process.env.RULE_DAILY_CAP_ENABLED = 'true'
-    const module = await buildTestingModule()
-    const service = module.get<GatewayService>(GatewayService)
-    await service.onModuleInit()
-    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
-  })
-
-  it('should set the rules config depending on env variables when empty', async () => {
-    process.env.RULE_CAPTCHA_CONFIG = ''
-    const module = await buildTestingModule()
-    const service = module.get<GatewayService>(GatewayService)
-    await service.onModuleInit()
-    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({ CAPTCHA: null }))
-  })
-
-  it('should set the rules config depending on env variables when valid', async () => {
-    process.env.RULE_CAPTCHA_CONFIG = '{"test": true}'
-    const module = await buildTestingModule()
-    const service = module.get<GatewayService>(GatewayService)
-    await service.onModuleInit()
-    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
-  })
 })

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -1,10 +1,10 @@
 import { HttpModule, HttpService } from '@nestjs/common'
-import { ConfigModule, ConfigType } from '@nestjs/config';
+import { ConfigModule, ConfigType } from '@nestjs/config'
 import { Test, TestingModule } from '@nestjs/testing'
-import { DeviceCheckService } from 'apps/onboarding/src/gateway/device-check/device-check.service';
-import { RuleID } from 'apps/onboarding/src/gateway/rules/rule';
-import { SafetyNetService } from 'apps/onboarding/src/gateway/safety-net/safety-net.service';
-import appConfig from 'apps/relayer/src/config/app.config';
+import { DeviceCheckService } from 'apps/onboarding/src/gateway/device-check/device-check.service'
+import { RuleID } from 'apps/onboarding/src/gateway/rules/rule'
+import { SafetyNetService } from 'apps/onboarding/src/gateway/safety-net/safety-net.service'
+import appConfig from 'apps/relayer/src/config/app.config'
 import rulesConfig, { RulesConfig } from '../config/rules.config'
 import thirdPartyConfig from '../config/third-party.config'
 import { CaptchaService } from './captcha/captcha.service'

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -20,7 +20,7 @@ describe('GatewayService', () => {
     expect(service).toBeDefined()
   })
 
-  it('should enable the rules depending on env variables', async () => {
+  xit('should enable the rules depending on env variables', async () => {
     process.env.RULE_DAILY_CAP_ENABLED = ''
     await service.onModuleInit()
     expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: false}))
@@ -30,7 +30,7 @@ describe('GatewayService', () => {
     expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
   })
 
-  it('should set the rules config depending on env variables', async () => {
+  xit('should set the rules config depending on env variables', async () => {
     process.env.RULE_CAPTCHA_CONFIG = ''
     await service.onModuleInit()
     expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: null}))

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -1,41 +1,68 @@
-import { Test, TestingModule } from '@nestjs/testing'
 import { HttpModule, HttpService } from '@nestjs/common'
-import { GatewayService } from './gateway.service'
-import { AppModule } from '../app.module'
+import { ConfigModule, ConfigType } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing'
+import { DeviceCheckService } from 'apps/onboarding/src/gateway/device-check/device-check.service';
+import { RuleID } from 'apps/onboarding/src/gateway/rules/rule';
+import { SafetyNetService } from 'apps/onboarding/src/gateway/safety-net/safety-net.service';
+import appConfig from 'apps/relayer/src/config/app.config';
+import rulesConfig from '../config/rules.config'
+import thirdPartyConfig from '../config/third-party.config'
 import { CaptchaService } from './captcha/captcha.service'
+import { GatewayService } from './gateway.service'
 
 describe('GatewayService', () => {
-  let service: GatewayService
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      imports: [HttpModule, AppModule],
-      providers: [GatewayService, CaptchaService]
+  const buildTestingModule = async (): Promise<TestingModule> => {
+    return Test.createTestingModule({
+      imports: [
+        HttpModule,
+        ConfigModule.forRoot({
+          load: [thirdPartyConfig, rulesConfig],
+        })
+      ],
+      providers: [
+        GatewayService,
+        CaptchaService,
+        DeviceCheckService,
+        SafetyNetService,
+      ]
     }).compile()
+  }
 
-    service = module.get<GatewayService>(GatewayService)
-  })
-
-  it('should be defined', () => {
+  it('should be defined', async () => {
+    const module = await buildTestingModule()
+    const service = module.get<GatewayService>(GatewayService)
     expect(service).toBeDefined()
   })
 
-  xit('should enable the rules depending on env variables', async () => {
+  it('should disable the rules depending on env variables when empty', async () => {
     process.env.RULE_DAILY_CAP_ENABLED = ''
+    const module = await buildTestingModule()
+    const service = module.get<GatewayService>(GatewayService)
     await service.onModuleInit()
-    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: false}))
+    expect((service as any).ruleEnabled).toEqual(expect.objectContaining({ DAILY_CAP: false }))
+  })
 
+  it('should enable the rules depending on env variables when true', async () => {
     process.env.RULE_DAILY_CAP_ENABLED = 'true'
+    const module = await buildTestingModule()
+    const service = module.get<GatewayService>(GatewayService)
     await service.onModuleInit()
     expect((service as any).ruleEnabled).toEqual(expect.objectContaining({DAILY_CAP: true}))
   })
 
-  xit('should set the rules config depending on env variables', async () => {
+  it('should set the rules config depending on env variables when empty', async () => {
     process.env.RULE_CAPTCHA_CONFIG = ''
+    const module = await buildTestingModule()
+    const service = module.get<GatewayService>(GatewayService)
     await service.onModuleInit()
-    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: null}))
+    expect((service as any).ruleConfigs).toEqual(expect.objectContaining({ CAPTCHA: null }))
+  })
 
+  it('should set the rules config depending on env variables when valid', async () => {
     process.env.RULE_CAPTCHA_CONFIG = '{"test": true}'
+    const module = await buildTestingModule()
+    const service = module.get<GatewayService>(GatewayService)
     await service.onModuleInit()
     expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
   })

--- a/apps/onboarding/src/gateway/gateway.service.spec.ts
+++ b/apps/onboarding/src/gateway/gateway.service.spec.ts
@@ -61,11 +61,11 @@ describe('GatewayService', () => {
     })
 
     it('should set the rules config depending on env variables when valid', async () => {
-      process.env.RULE_CAPTCHA_CONFIG = '{"test": true}'
+      process.env.RULE_DAILY_CAP_CONFIG = '{"test": true}'
       const module = await buildTestingModule()
       const service = module.get<GatewayService>(GatewayService)
       await service.onModuleInit()
-      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({DAILY_CAP: {test: true}}))
     })
   })
 
@@ -126,19 +126,19 @@ describe('GatewayService', () => {
       })
       const service = module.get<GatewayService>(GatewayService)
       await service.onModuleInit()
-      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({ CAPTCHA: null }))
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: null}))
     })
 
     it('should set the rules config depending on env variables when valid', async () => {
       const module = await buildTestingModuleForConfig({
         enabled: {},
         configs: {
-          [RuleID.Captcha]: {test: true}
+          [RuleID.DailyCap]: '{"test": true}'
         }
       })
       const service = module.get<GatewayService>(GatewayService)
       await service.onModuleInit()
-      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({CAPTCHA: {test: true}}))
+      expect((service as any).ruleConfigs).toEqual(expect.objectContaining({DAILY_CAP: {test: true}}))
     })
   })
 

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -27,7 +27,7 @@ export class GatewayService implements OnModuleInit {
     this.ruleEnabled = this.rules.reduce((acc, rule) => {
       return {
         ...acc,
-        [rule.getID()]: true
+        [rule.getID()]: process.env[`RULE_${rule.getID()}_ENABLED`] === 'true'
       }
     }, {})
 

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -1,13 +1,13 @@
-import { Injectable, OnModuleInit, Inject } from '@nestjs/common'
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common'
 import { ConfigType } from '@nestjs/config'
 import { ModuleRef } from '@nestjs/core'
 import { FastifyRequest } from 'fastify'
+import rulesConfig from '../config/rules.config'
 import { StartSessionDto } from '../dto/StartSessionDto'
 import { CaptchaRule } from './rules/captcha.rule'
 import { DailyCapRule } from './rules/daily-cap.rule'
 import { DeviceAttestationRule } from './rules/device-attestation.rule'
 import { GatewayContext, Rule } from './rules/rule'
-import rulesConfig from '../config/rules.config'
 
 @Injectable()
 export class GatewayService implements OnModuleInit {

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -34,7 +34,7 @@ export class GatewayService implements OnModuleInit {
     this.ruleConfigs = this.rules.reduce((acc, rule) => {
       return {
         ...acc,
-        [rule.getID()]: rule.defaultConfig()
+        [rule.getID()]: this.getConfigFromRule(rule)
       }
     }, {})
   }
@@ -58,5 +58,13 @@ export class GatewayService implements OnModuleInit {
     )
 
     return results.every(result => result.ok)
+  }
+
+  private getConfigFromRule<T>(rule: Rule<T, any>): T {
+    try {
+      return JSON.parse(process.env[`RULE_${rule.getID()}_CONFIG`])
+    } catch {
+      return rule.defaultConfig()
+    }
   }
 }

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -36,7 +36,7 @@ export class GatewayService implements OnModuleInit {
     this.ruleConfigs = this.rules.reduce((acc, rule) => {
       return {
         ...acc,
-        [rule.getID()]: this.config.configs[rule.getID()] || rule.defaultConfig()
+        [rule.getID()]: rule.validateConfig(this.config.configs[rule.getID()]) || rule.defaultConfig()
       }
     }, {})
   }

--- a/apps/onboarding/src/gateway/rules/captcha.rule.spec.ts
+++ b/apps/onboarding/src/gateway/rules/captcha.rule.spec.ts
@@ -27,7 +27,7 @@ describe('CaptchaRule', () => {
   })
 
   it('should have the correct id', () => {
-    expect(rule.getID()).toBe('CaptchaRule')
+    expect(rule.getID()).toBe('CAPTCHA')
   })
 
   it('should verify the token', async () => {

--- a/apps/onboarding/src/gateway/rules/captcha.rule.ts
+++ b/apps/onboarding/src/gateway/rules/captcha.rule.ts
@@ -34,7 +34,7 @@ export class CaptchaRule implements Rule<unknown, CaptchaServiceErrors> {
   }
 
   validateConfig(config: unknown): unknown {
-    return config
+    return null
   }
 
   defaultConfig(): unknown {

--- a/apps/onboarding/src/gateway/rules/captcha.rule.ts
+++ b/apps/onboarding/src/gateway/rules/captcha.rule.ts
@@ -8,14 +8,14 @@ import {
   CaptchaServiceErrors,
   ReCAPTCHAErrorTypes
 } from '../captcha/captcha.service'
-import { Rule } from './rule'
+import { Rule, RuleID } from './rule'
 
 @Injectable()
 export class CaptchaRule implements Rule<unknown, CaptchaServiceErrors> {
   constructor(private captchaService: CaptchaService) {}
 
   getID() {
-    return 'CaptchaRule'
+    return RuleID.Captcha
   }
 
   async verify(

--- a/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
+++ b/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
@@ -26,9 +26,8 @@ export class DailyCapRule implements Rule<DailyCapConfig, CapReachedError> {
     return Ok(true)
   }
 
-  validateConfig(config: unknown): DailyCapConfig {
-    // Check should happen via io-ts runtime types
-    return config as DailyCapConfig
+  validateConfig(config: string = 'null'): DailyCapConfig {
+    return JSON.parse(config) || null as DailyCapConfig
   }
 
   defaultConfig(): DailyCapConfig {

--- a/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
+++ b/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
@@ -26,8 +26,8 @@ export class DailyCapRule implements Rule<DailyCapConfig, CapReachedError> {
     return Ok(true)
   }
 
-  validateConfig(config: string = 'null'): DailyCapConfig {
-    return JSON.parse(config) || null as DailyCapConfig
+  validateConfig(config?: string): DailyCapConfig {
+    return JSON.parse(config || 'null') || null as DailyCapConfig
   }
 
   defaultConfig(): DailyCapConfig {

--- a/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
+++ b/apps/onboarding/src/gateway/rules/daily-cap.rule.ts
@@ -1,6 +1,6 @@
 import { Ok, RootError } from '@celo/base/lib/result'
 import { Injectable } from '@nestjs/common'
-import { Rule } from './rule'
+import { Rule, RuleID } from './rule'
 
 interface DailyCapConfig {
   total: number
@@ -19,7 +19,7 @@ export class CapReachedError extends RootError<DailyCapRuleErrorTypes> {
 @Injectable()
 export class DailyCapRule implements Rule<DailyCapConfig, CapReachedError> {
   getID() {
-    return 'DailyCapRule'
+    return RuleID.DailyCap
   }
 
   async verify(startSessionDto, config, context) {

--- a/apps/onboarding/src/gateway/rules/device-attestation.rule.ts
+++ b/apps/onboarding/src/gateway/rules/device-attestation.rule.ts
@@ -5,7 +5,7 @@ import {
   StartSessionDto
 } from 'apps/onboarding/src/dto/StartSessionDto'
 import { DeviceCheckService } from '../device-check/device-check.service'
-import { GatewayContext, Rule } from '../rules/rule'
+import { GatewayContext, Rule, RuleID } from '../rules/rule'
 import { SafetyNetService } from '../safety-net/safety-net.service'
 
 enum DeviceAttestationErrorTypes {
@@ -37,8 +37,8 @@ export class DeviceAttestationRule
     private safetyNetService: SafetyNetService
   ) {}
 
-  getID(): string {
-    return 'DeviceAttestationRule'
+  getID() {
+    return RuleID.DeviceAttestation
   }
 
   async verify(

--- a/apps/onboarding/src/gateway/rules/device-attestation.rule.ts
+++ b/apps/onboarding/src/gateway/rules/device-attestation.rule.ts
@@ -71,7 +71,7 @@ export class DeviceAttestationRule
   }
 
   validateConfig(config: unknown): unknown {
-    return config
+    return null
   }
 
   defaultConfig(): unknown {

--- a/apps/onboarding/src/gateway/rules/rule.ts
+++ b/apps/onboarding/src/gateway/rules/rule.ts
@@ -2,12 +2,18 @@ import { Result, RootError } from '@celo/base/lib/result'
 import { FastifyRequest } from 'fastify'
 import { StartSessionDto } from '../../dto/StartSessionDto'
 
+export enum RuleID {
+  DailyCap = 'DAILY_CAP',
+  Captcha = 'CAPTCHA',
+  DeviceAttestation = 'DEVICE_ATTESTATION',
+}
+
 export interface GatewayContext {
   req: FastifyRequest
 }
 
 export interface Rule<TRuleConfig, TErrorTypes extends Error> {
-  getID(): string
+  getID(): RuleID
   verify(
     payload: Partial<StartSessionDto>,
     config: TRuleConfig,

--- a/apps/onboarding/src/gateway/rules/rule.ts
+++ b/apps/onboarding/src/gateway/rules/rule.ts
@@ -19,6 +19,6 @@ export interface Rule<TRuleConfig, TErrorTypes extends Error> {
     config: TRuleConfig,
     context: GatewayContext
   ): Promise<Result<boolean, TErrorTypes>>
-  validateConfig(config: unknown): TRuleConfig
+  validateConfig(config: string | undefined): TRuleConfig
   defaultConfig(): TRuleConfig
 }


### PR DESCRIPTION
Closes #31 

To enable the rules will be necessary to use the following command before run start/test:
```export RULE_DAILY_CAP_ENABLED=true; export RULE_CAPTCHA_ENABLED=true; export RULE_DEVICE_ATTESTATION_ENABLED=true```