### PR TITLE
Transaction validation and filtering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           path: |
             libs/celo
-          key: ${{ runner.os }}-celo-${{ steps.celo-monorepo-commit.outputs.commit }}
+          key: ${{ runner.os }}-celo-${{ hashFiles('./scripts/build.celo.sh') }}-${{ steps.celo-monorepo-commit.outputs.commit }}
           only-check-key: true
       - name: Restore yarn cache
         uses: bowd/cache@v3
@@ -91,7 +91,7 @@ jobs:
         with:
           path: |
             libs/celo
-          key: ${{ runner.os }}-celo-${{ steps.celo-monorepo-commit.outputs.commit }}
+          key: ${{ runner.os }}-celo-${{ hashFiles('./scripts/build.celo.sh') }}-${{ steps.celo-monorepo-commit.outputs.commit }}
       - name: Restore Komenci cache
         id: restore-komenci
         uses: bowd/cache@v3

--- a/apps/onboarding/src/app.controller.spec.ts
+++ b/apps/onboarding/src/app.controller.spec.ts
@@ -2,6 +2,7 @@ import { appConfig } from '@app/onboarding/config/app.config'
 import { Session } from '@app/onboarding/session/session.entity'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
+import { ContractKit } from '@celo/contractkit'
 import { JwtModule, JwtService } from '@nestjs/jwt'
 import { Test, TestingModule } from '@nestjs/testing'
 import httpMocks from 'node-mocks-http'
@@ -17,20 +18,13 @@ jest.mock('./relayer_proxy.service')
 jest.mock('./session/session.service')
 jest.mock('./wallet/wallet.service')
 jest.mock('./subsidy/subsidy.service')
+jest.mock('@celo/contractKit')
 
 describe('AppController', () => {
   let appController: AppController
-  // @ts-ignore
-  const gatewayService: GatewayService = new GatewayService()
-  // @ts-ignore
-  const sessionService = new SessionService()
-  // @ts-ignore
-  const relayerService = new RelayerProxyService()
-  // @ts-ignore
-  const walletService = new WalletService()
-  // @ts-ignore
-  const subsidyService = new SubsidyService()
   let jwtService: JwtService
+  let gatewayService: GatewayService
+  let sessionService: SessionService
 
 
   beforeEach(async () => {
@@ -48,20 +42,18 @@ describe('AppController', () => {
         SessionService,
         WalletService,
         SubsidyService,
+        ContractKit,
         {
           provide: appConfig.KEY,
           useValue: appConfig.call(null)
         }
       ]
-    }).overrideProvider(GatewayService).useValue(gatewayService)
-      .overrideProvider(RelayerProxyService).useValue(relayerService)
-      .overrideProvider(SessionService).useValue(sessionService)
-      .overrideProvider(WalletService).useValue(walletService)
-      .overrideProvider(SubsidyService).useValue(subsidyService)
-      .compile()
+    }).compile()
 
-    appController = app.get<AppController>(AppController)
-    jwtService = app.get<JwtService>(JwtService)
+    appController = app.get(AppController)
+    jwtService = app.get(JwtService)
+    gatewayService = app.get(GatewayService)
+    sessionService = app.get(SessionService)
   })
 
   it('should be defined', () => {

--- a/apps/onboarding/src/app.controller.spec.ts
+++ b/apps/onboarding/src/app.controller.spec.ts
@@ -18,7 +18,7 @@ jest.mock('./relayer_proxy.service')
 jest.mock('./session/session.service')
 jest.mock('./wallet/wallet.service')
 jest.mock('./subsidy/subsidy.service')
-jest.mock('@celo/contractKit')
+jest.mock('@celo/contractkit')
 
 describe('AppController', () => {
   let appController: AppController

--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -182,6 +182,8 @@ export class AppController {
   private async allowedMetaTransactions(): Promise<TxFilter[]> {
     if (this._allowedMetaTransaction === undefined) {
       const attestations = await this.contractKit.contracts.getAttestations()
+      const accounts = await this.contractKit.contracts.getAccounts()
+
       this._allowedMetaTransaction = [
         {
           destination: attestations.address,
@@ -191,6 +193,10 @@ export class AppController {
           destination: attestations.address,
           methodId: attestations.methodIds.complete
         },
+        {
+          destination: accounts.address,
+          methodId: accounts.methodIds.setAccount
+        }
       ]
     }
     return this._allowedMetaTransaction

--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -163,7 +163,6 @@ export class AppController {
 
     const validTx = await this.walletService.isAllowedMetaTransaction(
       metaTx,
-      session,
       await this.allowedMetaTransactions()
     )
 

--- a/apps/onboarding/src/subsidy/subsidy.service.spec.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.spec.ts
@@ -1,6 +1,7 @@
 import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
 import { RequestAttestationsDto } from '@app/onboarding/dto/RequestAttestationsDto'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
+import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { ContractKit } from '@celo/contractkit'
 import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
 import { AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
@@ -13,6 +14,7 @@ jest.mock('@celo/contractkit')
 jest.mock('@celo/contractkit/lib/wrappers/Attestations')
 jest.mock('@celo/contractkit/lib/wrappers/StableTokenWrapper')
 jest.mock('@celo/contractkit/lib/contract-cache')
+jest.mock('@app/onboarding/wallet/wallet.service')
 
 // @ts-ignore
 const contractKit = new ContractKit()
@@ -34,6 +36,7 @@ describe('SubsidyService', () => {
       providers: [
         SubsidyService,
         ContractKit,
+        WalletService,
         {
           provide: appConfig.KEY,
           useValue: cfg

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -35,7 +35,6 @@ export class SubsidyService {
     const stableToken = await this.contractKit.contracts.getStableToken()
     const approveValid = await this.walletService.isAllowedMetaTransaction(
       input.transactions.approve,
-      session,
       [
         {
           destination: stableToken.address,
@@ -51,7 +50,6 @@ export class SubsidyService {
     const attestations = await this.contractKit.contracts.getAttestations()
     const requestValid = await this.walletService.isAllowedMetaTransaction(
       input.transactions.approve,
-      session,
       [
         {
           destination: attestations.address,

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -49,7 +49,7 @@ export class SubsidyService {
 
     const attestations = await this.contractKit.contracts.getAttestations()
     const requestValid = await this.walletService.isAllowedMetaTransaction(
-      input.transactions.approve,
+      input.transactions.request,
       [
         {
           destination: attestations.address,

--- a/apps/onboarding/src/utils/testing/mock-web3-provider.ts
+++ b/apps/onboarding/src/utils/testing/mock-web3-provider.ts
@@ -1,0 +1,30 @@
+import Web3 from 'web3'
+import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
+
+export type ResultForPayload = (payload: JsonRpcPayload) => [Error | null, JsonRpcResponse?]
+export const buildMockWeb3Provider = (resultForPayload: ResultForPayload) => {
+  const sendMock = jest.fn().mockImplementation((
+    payload: JsonRpcPayload,
+    callback: (error: Error | null, result?: JsonRpcResponse) => void
+  ) => {
+    const [err, result] = payload.params[0].to === '0x000000000000000000000000000000000000ce10'
+      ? [null, Web3.utils.randomHex(32)]
+      : resultForPayload(payload)
+
+    callback(err, {
+      jsonrpc: payload.jsonrpc,
+      id: parseInt(payload.id as any, 10),
+      result,
+    })
+  })
+
+  return jest.fn((_host, _options) => ({
+    host: _host,
+    connected: true,
+    send: sendMock,
+    supportsSubscriptions: () => true,
+    disconnect: () => true,
+  }))
+
+}
+

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -46,7 +46,7 @@ export class InvalidDestination extends RootError<MetaTxValidationErrorTypes> {
 }
 
 export class InputDecodeError extends RootError<MetaTxValidationErrorTypes> {
-  constructor(public readonly error: Error) {
+  constructor(public readonly error?: Error) {
     super(MetaTxValidationErrorTypes.InputDecodeError)
   }
 }

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -1,0 +1,61 @@
+import { RootError } from '@celo/base/lib/result'
+import { Input } from '@nestjs/cli/commands'
+
+export enum WalletErrorType {
+  NotDeployed = "NotDeployed",
+  InvalidImplementation = "InvalidImplementation"
+}
+
+export class WalletNotDeployed extends RootError<WalletErrorType> {
+  constructor() {
+    super(WalletErrorType.NotDeployed)
+  }
+}
+
+export class InvalidImplementation extends RootError<WalletErrorType> {
+  constructor(public readonly implementationAddress) {
+    super(WalletErrorType.InvalidImplementation)
+  }
+}
+
+export type WalletError = WalletNotDeployed | InvalidImplementation
+
+export enum MetaTxValidationErrorTypes {
+  InvalidRootMethod = "InvalidRootMethod",
+  InvalidChildMethod = "InvalidChildMethod",
+  InvalidDestination = "InvalidDestination",
+  InputDecodeError = "InputDecodeError"
+}
+
+export class InvalidRootMethod extends RootError<MetaTxValidationErrorTypes> {
+  constructor(public readonly received: string) {
+    super(MetaTxValidationErrorTypes.InvalidRootMethod)
+  }
+}
+
+export class InvalidChildMethod extends RootError<MetaTxValidationErrorTypes> {
+  constructor(public readonly received: string) {
+    super(MetaTxValidationErrorTypes.InvalidChildMethod)
+  }
+}
+
+export class InvalidDestination extends RootError<MetaTxValidationErrorTypes> {
+  constructor(public readonly received: string) {
+    super(MetaTxValidationErrorTypes.InvalidDestination)
+  }
+}
+
+export class InputDecodeError extends RootError<MetaTxValidationErrorTypes> {
+  constructor(public readonly error: Error) {
+    super(MetaTxValidationErrorTypes.InputDecodeError)
+  }
+}
+
+export type MetaTxValidationError =
+  InvalidRootMethod |
+  InvalidChildMethod |
+  InvalidDestination |
+  InputDecodeError
+
+
+

--- a/apps/onboarding/src/wallet/wallet.service.spec.ts
+++ b/apps/onboarding/src/wallet/wallet.service.spec.ts
@@ -55,7 +55,7 @@ describe("WalletService", () => {
 
   describe('#isAllowedMetaTransaction', () => {
     describe('with a random transaction', () => {
-      it('returns an DecodeError', async () => {
+      it('returns a DecodeError', async () => {
         const module = await buildModule({})
         const walletService = module.get(WalletService)
         const contractKit = module.get(ContractKit)
@@ -123,6 +123,8 @@ describe("WalletService", () => {
               {v: 0, r: "0x0", s: "0x0"}
             ).txo
           )
+
+          console.log(attestations.methodIds)
 
           const res = await walletService.isAllowedMetaTransaction(
             testTx,

--- a/apps/onboarding/src/wallet/wallet.service.spec.ts
+++ b/apps/onboarding/src/wallet/wallet.service.spec.ts
@@ -124,8 +124,6 @@ describe("WalletService", () => {
             ).txo
           )
 
-          console.log(attestations.methodIds)
-
           const res = await walletService.isAllowedMetaTransaction(
             testTx,
             [

--- a/apps/onboarding/src/wallet/wallet.service.spec.ts
+++ b/apps/onboarding/src/wallet/wallet.service.spec.ts
@@ -1,0 +1,503 @@
+import { BlockchainModule, ContractsModule } from '@app/blockchain'
+import { NodeProviderType } from '@app/blockchain/config/node.config'
+import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
+import { RelayerProxyService } from '@app/onboarding/relayer_proxy.service'
+import { Session } from '@app/onboarding/session/session.entity'
+import { SessionService } from '@app/onboarding/session/session.service'
+import { buildMockWeb3Provider } from '@app/onboarding/utils/testing/mock-web3-provider'
+import { MetaTxValidationErrorTypes, WalletErrorType } from '@app/onboarding/wallet/errors'
+import { WalletService } from '@app/onboarding/wallet/wallet.service'
+import { ContractKit } from '@celo/contractkit'
+import { toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { MetaTransactionWalletDeployerWrapper } from '@celo/contractkit/lib/wrappers/MetaTransactionWalletDeployer'
+import { Test, TestingModule } from '@nestjs/testing'
+import { LoggerModule } from 'nestjs-pino'
+import Web3 from 'web3'
+
+jest.mock('@app/onboarding/relayer_proxy.service')
+jest.mock('@app/onboarding/session/session.service')
+Web3.providers.HttpProvider = buildMockWeb3Provider(() => null)
+
+describe("WalletService", () => {
+  const buildModule = async (cfg: Partial<AppConfig>) => {
+    return Test.createTestingModule({
+      imports: [
+        LoggerModule.forRoot(),
+        BlockchainModule.forRootAsync({
+          useFactory: () => {
+            return {
+              node: {
+                providerType: NodeProviderType.HTTP,
+                url: "not-a-node"
+              }
+            }
+          }
+        }),
+        ContractsModule.forRootAsync({
+          useFactory: () => {
+            return {
+              deployerAddress: Web3.utils.randomHex(20)
+            }
+          },
+        }),
+      ],
+      providers: [
+        WalletService,
+        RelayerProxyService,
+        SessionService,
+        {
+          provide: appConfig.KEY,
+          useValue: cfg
+        },
+      ]
+    }).compile()
+  }
+
+  describe('#isAllowedMetaTransaction', () => {
+    describe('with a random transaction', () => {
+      it('returns an DecodeError', async () => {
+        const module = await buildModule({})
+        const walletService = module.get(WalletService)
+        const contractKit = module.get(ContractKit)
+
+        const attestations = await contractKit.contracts.getAttestations()
+        const testTx = toRawTransaction(
+          (await attestations.request("0x0", 3)).txo
+        )
+
+        const res = await walletService.isAllowedMetaTransaction(
+          testTx,
+          [
+            {
+              destination: attestations.address,
+              methodId: attestations.methodIds.request
+            }
+          ]
+        )
+
+        expect(res.ok).toBe(false)
+        if (res.ok === false) {
+          expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InputDecodeError)
+        }
+      })
+
+      it('returns an InvalidRootMethod', async () => {
+        const module = await buildModule({})
+        const walletService = module.get(WalletService)
+        const contractKit = module.get(ContractKit)
+
+        const attestations = await contractKit.contracts.getAttestations()
+        const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
+        const testTx = toRawTransaction(wallet.setSigner(Web3.utils.randomHex(20)).txo)
+
+        const res = await walletService.isAllowedMetaTransaction(
+          testTx,
+          [
+            {
+              destination: attestations.address,
+              methodId: attestations.methodIds.request
+            }
+          ]
+        )
+
+        expect(res.ok).toBe(false)
+        if (res.ok === false) {
+          expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidRootMethod)
+        }
+      })
+    })
+
+    describe('with a meta transaction', () => {
+      describe('pointing to an invalid destination', () => {
+        it('returns an InvalidDestination error', async () => {
+          const module = await buildModule({})
+          const walletService = module.get(WalletService)
+          const contractKit = module.get(ContractKit)
+
+          const attestations = await contractKit.contracts.getAttestations()
+          const stableToken = await contractKit.contracts.getStableToken()
+          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
+          const testTx = toRawTransaction(
+            wallet.executeMetaTransaction(
+              stableToken.transfer(Web3.utils.randomHex(20), "10000").txo,
+              {v: 0, r: "0x0", s: "0x0"}
+            ).txo
+          )
+
+          const res = await walletService.isAllowedMetaTransaction(
+            testTx,
+            [
+              {
+                destination: attestations.address,
+                methodId: attestations.methodIds.request
+              }
+            ]
+          )
+
+          expect(res.ok).toBe(false)
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidDestination)
+          }
+        })
+      })
+
+      describe('pointing to an invalid method', () => {
+        it('returns an InvalidChildMethod error', async () => {
+          const module = await buildModule({})
+          const walletService = module.get(WalletService)
+          const contractKit = module.get(ContractKit)
+
+          const attestations = await contractKit.contracts.getAttestations()
+          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
+          const testTx = toRawTransaction(
+            wallet.executeMetaTransaction(
+              attestations.selectIssuers("0x0").txo,
+              {v: 0, r: "0x0", s: "0x0"}
+            ).txo
+          )
+
+          const res = await walletService.isAllowedMetaTransaction(
+            testTx,
+            [
+              {
+                destination: attestations.address,
+                methodId: attestations.methodIds.request
+              }
+            ]
+          )
+
+          expect(res.ok).toBe(false)
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidChildMethod)
+          }
+        })
+      })
+
+      describe('which is allowed', () => {
+        it('returns ok!', async () => {
+          const module = await buildModule({})
+          const walletService = module.get(WalletService)
+          const contractKit = module.get(ContractKit)
+
+          const attestations = await contractKit.contracts.getAttestations()
+          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
+          const testTx = toRawTransaction(
+            wallet.executeMetaTransaction(
+              attestations.selectIssuers("0x0").txo,
+              {v: 0, r: "0x0", s: "0x0"}
+            ).txo
+          )
+
+          const res = await walletService.isAllowedMetaTransaction(
+            testTx,
+            [
+              {
+                destination: attestations.address,
+                methodId: attestations.methodIds.request
+              }
+            ]
+          )
+
+          expect(res.ok).toBe(false)
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidChildMethod)
+          }
+        })
+      })
+    })
+  })
+
+  describe('#deployWallet', () => {
+    const validImplementation = Web3.utils.randomHex(20)
+    const invalidImplementation = Web3.utils.randomHex(20)
+    const externalAccount = Web3.utils.randomHex(20)
+
+    let module: TestingModule
+    beforeEach(async () => {
+      module = await buildModule({
+        mtwImplementations: {
+          [validImplementation]: "1.1.0"
+        },
+        transactionTimeoutMs: 1000
+      })
+    })
+
+
+    describe('with an invalid implementation', () => {
+      it('returns an InvalidImplementation', async () => {
+        const session = Session.of({})
+        const walletSvc = module.get(WalletService)
+        const deployRes = await walletSvc.deployWallet(session, invalidImplementation)
+
+        expect(deployRes.ok).toBe(false)
+        if (deployRes.ok === false) {
+          expect(deployRes.error.errorType).toBe(WalletErrorType.InvalidImplementation)
+        }
+      })
+    })
+
+    describe('with a valid implementation', () => {
+      describe('on the first run', () => {
+        it('sends a transaction and updates the session', async () => {
+          const session = Session.of({
+            id: 'session-1',
+            externalAccount
+          })
+
+          const walletSvc = module.get(WalletService)
+          const sessionSvc = module.get(SessionService)
+          const relayerSvc = module.get(RelayerProxyService)
+          const txHash = Web3.utils.randomHex(32)
+
+          const submitTxSpy = jest.spyOn(
+            relayerSvc,
+            'submitTransaction'
+          ).mockResolvedValue({ payload: txHash, relayerAddress: '0x22' })
+
+          const updateSessionSpy = jest.spyOn(
+            sessionSvc,
+            'update'
+          ).mockResolvedValue(null)
+
+          const deployRes = await walletSvc.deployWallet(session, validImplementation)
+          expect(deployRes.ok).toBe(true)
+
+          if (deployRes.ok === true) {
+            expect(deployRes.result).toBe(txHash)
+            expect(submitTxSpy).toHaveBeenCalled()
+            expect(updateSessionSpy).toHaveBeenCalledWith(
+              session.id,
+              {
+                meta: {
+                  walletDeploy: expect.objectContaining({
+                    txHash,
+                    implementationAddress: validImplementation
+                  })
+                }
+              }
+            )
+          }
+        })
+      })
+
+      describe('on a subsequent run', () => {
+        describe('before the deadline passed', () => {
+          it('returns the same tx hash', async () => {
+            const txHash = Web3.utils.randomHex(32)
+            const session = Session.of({
+              id: 'session-1',
+              externalAccount,
+              meta: {
+                walletDeploy: {
+                  txHash,
+                  implementationAddress: validImplementation,
+                  startedAt: Date.now() - 100
+                }
+              }
+            })
+
+            const walletSvc = module.get(WalletService)
+            const deployRes = await walletSvc.deployWallet(session, validImplementation)
+            const sessionSvc = module.get(SessionService)
+            const relayerSvc = module.get(RelayerProxyService)
+
+            const submitTxSpy = jest.spyOn(relayerSvc, 'submitTransaction')
+            const updateSessionSpy = jest.spyOn(sessionSvc,'update')
+            expect(deployRes.ok).toBe(true)
+
+            if (deployRes.ok === true) {
+              expect(deployRes.result).toBe(txHash)
+              expect(submitTxSpy).not.toHaveBeenCalled()
+              expect(updateSessionSpy).not.toHaveBeenCalled()
+            }
+          })
+        })
+      })
+
+      describe('after the deadline has passed', () => {
+        it('executes a new tx', async () => {
+          const oldTxHash = Web3.utils.randomHex(32)
+          const session = Session.of({
+            id: 'session-1',
+            externalAccount,
+            meta: {
+              walletDeploy: {
+                txHash: oldTxHash,
+                implementationAddress: validImplementation,
+                startedAt: Date.now() - 5000
+              }
+            }
+          })
+
+          const walletSvc = module.get(WalletService)
+          const sessionSvc = module.get(SessionService)
+          const relayerSvc = module.get(RelayerProxyService)
+          const txHash = Web3.utils.randomHex(32)
+
+          const submitTxSpy = jest.spyOn(
+            relayerSvc,
+            'submitTransaction'
+          ).mockResolvedValue({ payload: txHash, relayerAddress: '0x22' })
+
+          const updateSessionSpy = jest.spyOn(
+            sessionSvc,
+            'update'
+          ).mockResolvedValue(null)
+
+          const deployRes = await walletSvc.deployWallet(session, validImplementation)
+          expect(deployRes.ok).toBe(true)
+
+          if (deployRes.ok === true) {
+            expect(deployRes.result).toBe(txHash)
+            expect(submitTxSpy).toHaveBeenCalled()
+            expect(updateSessionSpy).toHaveBeenCalledWith(
+              session.id,
+              {
+                meta: {
+                  walletDeploy: expect.objectContaining({
+                    txHash,
+                    implementationAddress: validImplementation
+                  })
+                }
+              }
+            )
+          }
+        })
+      })
+    })
+  })
+
+  describe('#getWallet', () => {
+    const validImplementation = Web3.utils.randomHex(20)
+    const externalAccount = Web3.utils.randomHex(20)
+
+    let module: TestingModule
+    beforeEach(async () => {
+      module = await buildModule({
+        mtwImplementations: {
+          [validImplementation]: "1.1.0"
+        },
+        transactionTimeoutMs: 1000
+      })
+    })
+
+    describe('when no metadata is recorded on the session', () => {
+      it('returns WalletNotDeployed', async () => {
+        const session = Session.of({
+          id: 'session-1',
+          externalAccount
+        })
+
+        const walletSvc = module.get(WalletService)
+        const walletRes = await walletSvc.getWallet(session, validImplementation)
+
+        expect(walletRes.ok).toBe(false)
+        if (walletRes.ok === false) {
+          expect(walletRes.error.errorType).toBe(WalletErrorType.NotDeployed)
+        }
+      })
+    })
+
+    describe('with metadata pointing to a deploy tx', () => {
+      const buildTx = (txHash: string, blockNumber: number | null) => ({
+        hash: txHash,
+        nonce: 10,
+        blockNumber,
+        blockHash: blockNumber === null ? null : Web3.utils.randomHex(64),
+        transactionIndex: blockNumber == null ? null : 10,
+        from: Web3.utils.randomHex(20),
+        to: Web3.utils.randomHex(20),
+        value: "0",
+        input: "0x0",
+        gasPrice: "0x0",
+        gas: 0
+      })
+
+      describe('which is still pending', () => {
+        it('returns WalletNotDeployed', async () => {
+          const txHash = Web3.utils.randomHex(32)
+          const session = Session.of({
+            id: 'session-1',
+            externalAccount,
+            meta: {
+              walletDeploy: {
+                txHash,
+                implementationAddress: validImplementation,
+                startedAt: Date.now() - 100
+              }
+            }
+          })
+
+          const walletSvc = module.get(WalletService)
+          const deployer = module.get(MetaTransactionWalletDeployerWrapper)
+          const web3 = module.get(Web3)
+
+          const tx = buildTx(txHash, null)
+          const getTxSpy = jest.spyOn(web3.eth, 'getTransaction').mockResolvedValue(tx)
+
+          const walletRes = await walletSvc.getWallet(session, validImplementation)
+          expect(walletRes.ok).toBe(false)
+          if (walletRes.ok === false) {
+            expect(walletRes.error.errorType).toBe(WalletErrorType.NotDeployed)
+          }
+        })
+      })
+
+      describe('which is no longer pending', () => {
+        it('returns the wallet address', async () => {
+          const txHash = Web3.utils.randomHex(32)
+          const walletAddress = Web3.utils.randomHex(20)
+          const session = Session.of({
+            id: 'session-1',
+            externalAccount,
+            meta: {
+              walletDeploy: {
+                txHash,
+                implementationAddress: validImplementation,
+                startedAt: Date.now() - 100
+              }
+            }
+          })
+
+          const walletSvc = module.get(WalletService)
+          const deployer = module.get(MetaTransactionWalletDeployerWrapper)
+          const web3 = module.get(Web3)
+
+          const tx = buildTx(txHash, 2019)
+          const getTxSpy = jest.spyOn(web3.eth, 'getTransaction').mockResolvedValue(tx)
+
+          const getPastEventsSpy = jest.spyOn(deployer, 'getPastEvents').mockResolvedValue([
+            {
+              address: deployer.address,
+              blockHash: tx.blockHash,
+              blockNumber: tx.blockNumber,
+              event: "0x1",
+              logIndex: 10,
+              transactionIndex: 10,
+              transactionHash: txHash,
+              returnValues: {
+                owner: externalAccount,
+                wallet: walletAddress
+              }
+            }
+          ])
+
+          const walletRes = await walletSvc.getWallet(session, validImplementation)
+
+          expect(walletRes.ok).toBe(true)
+          if (walletRes.ok === true) {
+            expect(getTxSpy).toHaveBeenCalledWith(txHash)
+            expect(getPastEventsSpy).toHaveBeenCalledWith(
+              deployer.eventTypes.WalletDeployed,
+              {
+                fromBlock: tx.blockNumber,
+                toBlock: tx.blockNumber
+              }
+            )
+            expect(walletRes.result).toBe(walletAddress)
+          }
+        })
+      })
+    })
+  })
+})

--- a/libs/blockchain/src/utils.ts
+++ b/libs/blockchain/src/utils.ts
@@ -1,0 +1,11 @@
+import { normalizeAddress, trimLeading0x } from '@celo/base'
+
+// The method id (or method selector) is the first 4 bytes
+// of the calldata => the first 8 chars in hex
+export const extractMethodId = (calldata: string): string => {
+  return trimLeading0x(calldata).slice(0, 8).toLocaleLowerCase()
+}
+
+export const normalizeMethodId = (methodId: string): string => {
+  return trimLeading0x(methodId).toLocaleLowerCase()
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "axios": "^0.20.0",
     "btoa": "^1.2.1",
     "class-validator": "^0.12.2",
+    "ethereum-input-data-decoder": "^0.3.1",
     "fastify": "^3.3.0",
     "fp-ts": "^2.8.3",
     "global": "^4.4.0",
@@ -60,7 +61,6 @@
     "web3-core-helpers": "1.2.4"
   },
   "devDependencies": {
-    "bignumber.js": "9.0.0",
     "@celo/typescript": "^0.0.1",
     "@nestjs/cli": "^7.5.1",
     "@nestjs/schematics": "^7.0.0",
@@ -74,6 +74,7 @@
     "@types/supertest": "^2.0.8",
     "@typescript-eslint/eslint-plugin": "3.0.2",
     "@typescript-eslint/parser": "3.0.2",
+    "bignumber.js": "9.0.0",
     "blind-threshold-bls": "https://github.com/celo-org/blind-threshold-bls-wasm#e1e2f8a",
     "class-transformer": "^0.3.1",
     "eslint": "7.1.0",

--- a/scripts/build.celo.sh
+++ b/scripts/build.celo.sh
@@ -5,4 +5,5 @@ yarn --cwd ./libs/celo/packages/utils build
 yarn --cwd ./libs/celo/packages/dev-utils build
 yarn --cwd ./libs/celo/packages/contractkit build:gen
 yarn --cwd ./libs/celo/packages/contractkit build
+yarn --cwd ./libs/celo/packages/komencikit build
 yarn --cwd ./libs/celo/packages/phone-number-privacy/common build

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-find-index@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-find-index/-/array-find-index-1.0.2.tgz#df010aa1287e164bbda6f9723b0a96a1ec4187a1"
+  integrity sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -1924,6 +1929,11 @@ array.prototype.flat@^1.2.3:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+arrify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+  integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
 asn1.js@^5.2.0:
   version "5.4.1"
@@ -3131,6 +3141,15 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
+camelcase-keys@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-4.2.0.tgz#a2aa5fb1af688758259c32c141426d78923b9b77"
+  integrity sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
+
 camelcase@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
@@ -3764,6 +3783,13 @@ cssstyle@^2.2.0:
   dependencies:
     cssom "~0.3.6"
 
+currently-unhandled@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
+  integrity sha1-mI3zP+qxke95mmE2nddsF635V+o=
+  dependencies:
+    array-find-index "^1.0.1"
+
 cyclist@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
@@ -3819,7 +3845,15 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "2.1.2"
 
-decamelize@^1.2.0:
+decamelize-keys@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/decamelize-keys/-/decamelize-keys-1.1.0.tgz#d171a87933252807eb3cb61dc1c1445d078df2d9"
+  integrity sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
+  dependencies:
+    decamelize "^1.1.0"
+    map-obj "^1.0.0"
+
+decamelize@^1.1.0, decamelize@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
@@ -4819,6 +4853,18 @@ ethereum-ens@^0.8.0:
     underscore "^1.8.3"
     web3 "^1.0.0-beta.34"
 
+ethereum-input-data-decoder@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/ethereum-input-data-decoder/-/ethereum-input-data-decoder-0.3.1.tgz#5c209cab88988547e7262d7d92e4065c1168fd26"
+  integrity sha512-zl3QLiHeGG94Ru9uvBeX80ZLj62YXew9JVBUR2QiU2o+wJ9kkRdTAcLD3MJq+4guabj4U2H8s3pBlamrbRzpvA==
+  dependencies:
+    bn.js "^4.11.8"
+    buffer "^5.2.1"
+    ethereumjs-abi "^0.6.7"
+    ethers "^4.0.27"
+    is-buffer "^2.0.3"
+    meow "^5.0.0"
+
 ethereum-protocol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ethereum-protocol/-/ethereum-protocol-1.0.1.tgz#b7d68142f4105e0ae7b5e178cf42f8d4dc4b93cf"
@@ -4840,7 +4886,7 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-abi@^0.6.8:
+ethereumjs-abi@^0.6.7, ethereumjs-abi@^0.6.8:
   version "0.6.8"
   resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
   integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
@@ -5055,7 +5101,7 @@ ethers@4.0.0-beta.3:
     uuid "2.0.1"
     xmlhttprequest "1.8.0"
 
-ethers@^4.0.0-beta.1, ethers@^4.0.32:
+ethers@^4.0.0-beta.1, ethers@^4.0.27, ethers@^4.0.32:
   version "4.0.48"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.48.tgz#330c65b8133e112b0613156e57e92d9009d8fbbe"
   integrity sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==
@@ -6279,6 +6325,11 @@ imurmurhash@^0.1.4:
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
 
+indent-string@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
+  integrity sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
 infer-owner@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/infer-owner/-/infer-owner-1.0.4.tgz#c4cefcaa8e51051c2a40ba2ce8a3d27295af9467"
@@ -6414,6 +6465,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
 
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.0, is-callable@^1.2.2:
   version "1.2.2"
@@ -7235,7 +7291,7 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
-json-parse-better-errors@^1.0.2:
+json-parse-better-errors@^1.0.1, json-parse-better-errors@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
@@ -7634,6 +7690,16 @@ load-json-file@^2.0.0:
     pify "^2.0.0"
     strip-bom "^3.0.0"
 
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
 loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -7816,6 +7882,14 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loud-rejection@^1.0.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/loud-rejection/-/loud-rejection-1.6.0.tgz#5b46f80147edee578870f086d04821cf998e551f"
+  integrity sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=
+  dependencies:
+    currently-unhandled "^0.4.1"
+    signal-exit "^3.0.0"
+
 lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
@@ -7908,6 +7982,16 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
+map-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+  integrity sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+  integrity sha1-plzSkIepJZi4eRJXpSPgISIqwfk=
+
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
@@ -7989,6 +8073,21 @@ memory-fs@^0.5.0:
   dependencies:
     errno "^0.1.3"
     readable-stream "^2.0.1"
+
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
 
 merge-descriptors@1.0.1, merge-descriptors@^1.0.1:
   version "1.0.1"
@@ -8118,6 +8217,14 @@ minimatch@^3.0.4:
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist-options@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-3.0.2.tgz#fba4c8191339e13ecf4d61beb03f070103f3d954"
+  integrity sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==
+  dependencies:
+    arrify "^1.0.1"
+    is-plain-obj "^1.1.0"
 
 minimist@1.2.5, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@~1.2.5:
   version "1.2.5"
@@ -8477,7 +8584,7 @@ node-notifier@^8.0.0:
     uuid "^8.3.0"
     which "^2.0.2"
 
-normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
+normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -8902,6 +9009,14 @@ parse-json@^2.2.0:
   dependencies:
     error-ex "^1.2.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
 parse-json@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.1.0.tgz#f96088cdf24a8faa9aea9a009f2d9d942c999646"
@@ -9028,6 +9143,13 @@ path-type@^2.0.0:
   integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -9525,6 +9647,11 @@ quick-format-unescaped@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.1.tgz#437a5ea1a0b61deb7605f8ab6a8fd3858dbeb701"
   integrity sha512-RyYpQ6Q5/drsJyOhrWHYMWTedvjTIat+FTwv0K4yoUxzvekw2aRHMQJLlnvt8UantkZg2++bEzD9EdxXqkWf4A==
 
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
+  integrity sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=
+
 randombytes@^2.0.0, randombytes@^2.0.1, randombytes@^2.0.5, randombytes@^2.0.6, randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -9573,6 +9700,14 @@ read-pkg-up@^2.0.0:
     find-up "^2.0.0"
     read-pkg "^2.0.0"
 
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -9590,6 +9725,15 @@ read-pkg@^2.0.0:
     load-json-file "^2.0.0"
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
 
 read-pkg@^5.2.0:
   version "5.2.0"
@@ -9665,6 +9809,14 @@ rechoir@^0.6.2:
   integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
   dependencies:
     resolve "^1.1.6"
+
+redent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/redent/-/redent-2.0.0.tgz#c1b2007b42d57eb1389079b3c8333639d5e1ccaa"
+  integrity sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=
+  dependencies:
+    indent-string "^3.0.0"
+    strip-indent "^2.0.0"
 
 reflect-metadata@^0.1.13:
   version "0.1.13"
@@ -11117,6 +11269,11 @@ tree-kill@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+
+trim-newlines@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-2.0.0.tgz#b403d0b91be50c331dfc4b82eeceb22c3de16d20"
+  integrity sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -13003,6 +13160,13 @@ yargs-parser@18.x, yargs-parser@^18.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^13.1.2:
   version "13.1.2"


### PR DESCRIPTION
### Overview

We need a solution to decode the meta transaction payload in two scenarios:
- when requesting the subsidy attestation we want to ensure that the two txs passed in are specifically an cUSD.approve and Attestations.request
- when passing in an arbitrary meta-tx it is validated agains the allowed transactions.

