### PR TITLE
Split approve and request in two steps to help with the mobile flow

### DIFF
--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -183,6 +183,7 @@ export class AppController {
     if (this._allowedMetaTransaction === undefined) {
       const attestations = await this.contractKit.contracts.getAttestations()
       const accounts = await this.contractKit.contracts.getAccounts()
+      const cUSD = await this.contractKit.contracts.getStableToken()
 
       this._allowedMetaTransaction = [
         {
@@ -196,6 +197,10 @@ export class AppController {
         {
           destination: accounts.address,
           methodId: accounts.methodIds.setAccount
+        },
+        {
+          destination: cUSD.address,
+          methodId: cUSD.methodIds.approve
         }
       ]
     }

--- a/apps/onboarding/src/dto/RequestAttestationsDto.ts
+++ b/apps/onboarding/src/dto/RequestAttestationsDto.ts
@@ -8,14 +8,6 @@ import {
   ValidateNested,
 } from 'class-validator'
 
-export class RequestAttestationsTransactionsDto {
-  @ValidateNested()
-  approve: RawTransactionDto
-
-  @ValidateNested()
-  request: RawTransactionDto
-}
-
 export class RequestAttestationsDto {
   @IsString()
   @IsNotEmpty()
@@ -29,6 +21,6 @@ export class RequestAttestationsDto {
   walletAddress: string
 
   @ValidateNested()
-  transactions: RequestAttestationsTransactionsDto
+  requestTx: RawTransactionDto
 }
 

--- a/apps/onboarding/src/subsidy/subsidy.service.spec.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.spec.ts
@@ -56,18 +56,11 @@ describe('SubsidyService', () => {
       identifier: Web3.utils.randomHex(10),
       attestationsRequested: 3,
       walletAddress,
-      transactions: {
-        approve: {
-          destination: walletAddress,
-          data: 'approve',
-          value: "0",
-        },
-        request: {
-          destination: walletAddress,
-          data: 'request',
-          value: "0",
-        },
-      }
+      requestTx: {
+        destination: walletAddress,
+        data: 'request',
+        value: "0",
+      },
     }
 
     let getAttestationStat: jest.SpyInstance
@@ -131,7 +124,7 @@ describe('SubsidyService', () => {
 
       it('outputs 5 transactions', async () => {
         const batch = await service.buildTransactionBatch(input)
-        expect(batch.length).toEqual(5)
+        expect(batch.length).toEqual(4)
 
         expect(getAttestationStat).toHaveBeenCalled()
         expect(transfer).toHaveBeenCalledWith(input.walletAddress, new BigNumber(100 * input.attestationsRequested).toFixed())
@@ -159,7 +152,7 @@ describe('SubsidyService', () => {
 
       it('outputs 3 transactions', async () => {
         const batch = await service.buildTransactionBatch(input)
-        expect(batch.length).toEqual(3)
+        expect(batch.length).toEqual(2)
 
         expect(getAttestationStat).not.toHaveBeenCalled()
         expect(transfer).toHaveBeenCalledWith(input.walletAddress, new BigNumber(100 * input.attestationsRequested).toFixed())

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -32,24 +32,9 @@ export class SubsidyService {
       return walletValid
     }
 
-    const stableToken = await this.contractKit.contracts.getStableToken()
-    const approveValid = await this.walletService.isAllowedMetaTransaction(
-      input.transactions.approve,
-      [
-        {
-          destination: stableToken.address,
-          methodId: stableToken.methodIds.approve,
-        }
-      ]
-    )
-
-    if (approveValid.ok === false) {
-      return approveValid
-    }
-
     const attestations = await this.contractKit.contracts.getAttestations()
     const requestValid = await this.walletService.isAllowedMetaTransaction(
-      input.transactions.request,
+      input.requestTx,
       [
         {
           destination: attestations.address,
@@ -69,13 +54,12 @@ export class SubsidyService {
     input: RequestAttestationsDto
   ): Promise<RawTransaction[]> {
     const {
-      identifier, walletAddress, transactions, attestationsRequested
+      identifier, walletAddress, attestationsRequested, requestTx
     } = input
 
     const batch = [
       await this.buildSubsidyTransfer(attestationsRequested, walletAddress),
-      transactions.approve,
-      transactions.request,
+      requestTx,
     ]
 
     if (!this.cfg.useAttestationGuards) {


### PR DESCRIPTION
Based on discussions with @tarikbellamine it looks like it's more ergonomic at the moment from the Valora perspective to have these as two separate operations.