### PR TITLE
Fix outstanding logging issues and improve Relayer error boundary

### DIFF
--- a/apps/onboarding/src/app.module.ts
+++ b/apps/onboarding/src/app.module.ts
@@ -60,7 +60,6 @@ import { SessionModule } from './session/session.module'
                   url: req.url,
                   hostname: req.hostname,
                   remoteAddress: req.ip,
-                  body: req.raw.body
                 }
               }
             },

--- a/apps/onboarding/src/auth/auth.service.ts
+++ b/apps/onboarding/src/auth/auth.service.ts
@@ -19,6 +19,8 @@ export enum AuthErrorTypes {
 
 export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken, undefined> {
   statusCode = 401
+  metadataProps = []
+
   constructor() {
     super(AuthErrorTypes.InvalidToken)
     this.message = 'Invalid or outdated token'
@@ -27,8 +29,10 @@ export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken, undefine
 
 export class SessionUnavailable extends ApiError<AuthErrorTypes.SessionUnavailable> {
   statusCode = 401
-  constructor(meta: {sessionId: string}) {
-    super(AuthErrorTypes.SessionUnavailable, meta)
+  metadataProps = ['sessionId']
+
+  constructor(readonly sessionId: string) {
+    super(AuthErrorTypes.SessionUnavailable)
     this.message = 'Session no longer available'
   }
 }
@@ -61,7 +65,7 @@ export class AuthService {
     if (session) {
       return session
     } else {
-      throw new SessionUnavailable({sessionId: payload.sessionId})
+      throw new SessionUnavailable(payload.sessionId)
     }
   }
 }

--- a/apps/onboarding/src/auth/auth.service.ts
+++ b/apps/onboarding/src/auth/auth.service.ts
@@ -17,7 +17,7 @@ export enum AuthErrorTypes {
   SessionUnavailable = "SessionUnavailable"
 }
 
-export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken, undefined> {
+export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken> {
   statusCode = 401
   metadataProps = []
 

--- a/apps/onboarding/src/auth/auth.service.ts
+++ b/apps/onboarding/src/auth/auth.service.ts
@@ -17,7 +17,7 @@ export enum AuthErrorTypes {
   SessionUnavailable = "SessionUnavailable"
 }
 
-export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken> {
+export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken, undefined> {
   statusCode = 401
   constructor() {
     super(AuthErrorTypes.InvalidToken)
@@ -25,10 +25,10 @@ export class InvalidToken extends ApiError<AuthErrorTypes.InvalidToken> {
   }
 }
 
-export class SessionUnavailable extends ApiError<AuthErrorTypes.SessionUnavailable, { sessionId: string }> {
+export class SessionUnavailable extends ApiError<AuthErrorTypes.SessionUnavailable> {
   statusCode = 401
-  constructor(private readonly sessionId: string) {
-    super(AuthErrorTypes.SessionUnavailable, { sessionId })
+  constructor(meta: {sessionId: string}) {
+    super(AuthErrorTypes.SessionUnavailable, meta)
     this.message = 'Session no longer available'
   }
 }
@@ -61,7 +61,7 @@ export class AuthService {
     if (session) {
       return session
     } else {
-      throw new SessionUnavailable(payload.sessionId)
+      throw new SessionUnavailable({sessionId: payload.sessionId})
     }
   }
 }

--- a/apps/onboarding/src/gateway/captcha/captcha.service.spec.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.spec.ts
@@ -106,8 +106,7 @@ describe('CaptchaService', () => {
         ReCAPTCHAErrorTypes.VerificationFailed
       )
       if (result.error.errorType === ReCAPTCHAErrorTypes.VerificationFailed) {
-        // type inference for error
-        expect(result.error.metadata.errorCodes).toEqual(errorCodes)
+        expect(result.error.errorCodes).toEqual(errorCodes)
       }
     }
   })

--- a/apps/onboarding/src/gateway/captcha/captcha.service.spec.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.spec.ts
@@ -107,7 +107,7 @@ describe('CaptchaService', () => {
       )
       if (result.error.errorType === ReCAPTCHAErrorTypes.VerificationFailed) {
         // type inference for error
-        expect(result.error.errorCodes).toEqual(errorCodes)
+        expect(result.error.metadata.errorCodes).toEqual(errorCodes)
       }
     }
   })

--- a/apps/onboarding/src/gateway/captcha/captcha.service.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.ts
@@ -1,3 +1,4 @@
+import { MetadataError } from '@app/komenci-logger/errors'
 import { Err, Ok, Result, RootError } from '@celo/base/lib/result'
 import {
   HttpService,
@@ -9,12 +10,12 @@ import { HttpRequestError } from '../../errors/http'
 import { ErrorCode, ReCAPTCHAResponseDto } from './ReCAPTCHAResponseDto'
 
 export enum ReCAPTCHAErrorTypes {
-  VerificationFailed = 'VerificationFailed'
+  VerificationFailed = 'RecaptchaVerificationFailed'
 }
 
-export class CaptchaVerificationFailed extends RootError<ReCAPTCHAErrorTypes> {
+export class CaptchaVerificationFailed extends MetadataError<ReCAPTCHAErrorTypes, {errorCodes: ErrorCode[]}> {
   constructor(public errorCodes: ErrorCode[]) {
-    super(ReCAPTCHAErrorTypes.VerificationFailed)
+    super(ReCAPTCHAErrorTypes.VerificationFailed, {errorCodes})
   }
 }
 

--- a/apps/onboarding/src/gateway/captcha/captcha.service.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.ts
@@ -14,9 +14,8 @@ export enum ReCAPTCHAErrorTypes {
 }
 
 export class CaptchaVerificationFailed extends MetadataError<ReCAPTCHAErrorTypes> {
-  constructor(
-    public readonly metadata: {errorCodes: ErrorCode[], token: string}
-  ) {
+  metadataProps = ['errorCodes', 'token']
+  constructor(readonly errorCodes: ErrorCode[], readonly token: string) {
     super(ReCAPTCHAErrorTypes.VerificationFailed)
   }
 }
@@ -46,10 +45,10 @@ export class CaptchaService {
         if (data.success === true) {
           return Ok(true)
         } else {
-          return Err(new CaptchaVerificationFailed({
-            errorCodes: data['error-codes'],
-            token: token
-          }))
+          return Err(new CaptchaVerificationFailed(
+            data['error-codes'],
+            token
+          ))
         }
       })
       .catch(error => {

--- a/apps/onboarding/src/gateway/captcha/captcha.service.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.ts
@@ -13,9 +13,9 @@ export enum ReCAPTCHAErrorTypes {
   VerificationFailed = 'RecaptchaVerificationFailed'
 }
 
-export class CaptchaVerificationFailed extends MetadataError<ReCAPTCHAErrorTypes, {errorCodes: ErrorCode[]}> {
-  constructor(public errorCodes: ErrorCode[]) {
-    super(ReCAPTCHAErrorTypes.VerificationFailed, {errorCodes})
+export class CaptchaVerificationFailed extends MetadataError<ReCAPTCHAErrorTypes> {
+  constructor(meta: {errorCodes: ErrorCode[], token: string}) {
+    super(ReCAPTCHAErrorTypes.VerificationFailed, meta)
   }
 }
 
@@ -44,7 +44,10 @@ export class CaptchaService {
         if (data.success === true) {
           return Ok(true)
         } else {
-          return Err(new CaptchaVerificationFailed(data['error-codes']))
+          return Err(new CaptchaVerificationFailed({
+            errorCodes: data['error-codes'],
+            token: token
+          }))
         }
       })
       .catch(error => {

--- a/apps/onboarding/src/gateway/captcha/captcha.service.ts
+++ b/apps/onboarding/src/gateway/captcha/captcha.service.ts
@@ -14,8 +14,10 @@ export enum ReCAPTCHAErrorTypes {
 }
 
 export class CaptchaVerificationFailed extends MetadataError<ReCAPTCHAErrorTypes> {
-  constructor(meta: {errorCodes: ErrorCode[], token: string}) {
-    super(ReCAPTCHAErrorTypes.VerificationFailed, meta)
+  constructor(
+    public readonly metadata: {errorCodes: ErrorCode[], token: string}
+  ) {
+    super(ReCAPTCHAErrorTypes.VerificationFailed)
   }
 }
 

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -68,8 +68,7 @@ export class GatewayService implements OnModuleInit {
     results.forEach((result, idx) => {
       this.logger.event(EventType.RuleVerified, {
         externalAccount: startSessionDto.externalAccount,
-        ruleId: enabledRules[idx].getID(),
-        result
+        result: result.ok
       })
 
       if (result.ok === false) {

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -67,6 +67,7 @@ export class GatewayService implements OnModuleInit {
     let hasFailingResult = false
     results.forEach((result, idx) => {
       this.logger.event(EventType.RuleVerified, {
+        ruleId: enabledRules[idx].getID(),
         externalAccount: startSessionDto.externalAccount,
         result: result.ok
       })

--- a/apps/onboarding/src/main.ts
+++ b/apps/onboarding/src/main.ts
@@ -7,7 +7,7 @@ import { appConfig } from './config/app.config'
 
 async function bootstrap() {
   const app = await NestFactory.create<NestApplication>(AppModule, {
-    logger: process.env.NODE_ENV !== "production"
+    logger: process.env.NODE_ENV === "production" ? false : undefined
   })
   const logger = app.get(Logger)
   app.useLogger(logger)

--- a/apps/onboarding/src/main.ts
+++ b/apps/onboarding/src/main.ts
@@ -6,7 +6,9 @@ import { AppModule } from './app.module'
 import { appConfig } from './config/app.config'
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestApplication>(AppModule)
+  const app = await NestFactory.create<NestApplication>(AppModule, {
+    logger: process.env.NODE_ENV !== "production"
+  })
   const logger = app.get(Logger)
   app.useLogger(logger)
   const cfg = app.get(ConfigService).get<ConfigType<typeof appConfig>>('app')

--- a/apps/onboarding/src/relayer/relayer_proxy.service.ts
+++ b/apps/onboarding/src/relayer/relayer_proxy.service.ts
@@ -20,20 +20,29 @@ export enum RelayerErrorTypes {
 }
 
 class RelayerTimeout extends MetadataError<RelayerErrorTypes.RelayerTimeout> {
-  constructor(meta: {cmd: RelayerCmd}) {
-    super(RelayerErrorTypes.RelayerTimeout, meta)
+  constructor(
+    public readonly metadata: {cmd: RelayerCmd}
+  ) {
+    super(RelayerErrorTypes.RelayerTimeout)
   }
 }
 
 class RelayerCommunicationError extends MetadataError<RelayerErrorTypes.RelayerCommunicationError> {
-  constructor(meta: {message, cmd}) {
-    super(RelayerErrorTypes.RelayerCommunicationError, meta)
+  constructor(
+    public readonly metadata: {message, cmd}
+  ) {
+    super(RelayerErrorTypes.RelayerCommunicationError)
   }
 }
 
 class RelayerInternalError extends MetadataError<RelayerErrorTypes.RelayerInternalError> {
-  constructor(meta: {errorType: string, message: string, metadata: any}) {
-    super(RelayerErrorTypes.RelayerInternalError, meta)
+  constructor(
+    public readonly metadata: {
+      errorType: string,
+      message: string,
+      metadata: any
+  }) {
+    super(RelayerErrorTypes.RelayerInternalError)
   }
 }
 

--- a/apps/onboarding/src/relayer/relayer_proxy.service.ts
+++ b/apps/onboarding/src/relayer/relayer_proxy.service.ts
@@ -1,29 +1,44 @@
+import { MetadataError } from '@app/komenci-logger/errors'
 import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
 import { DistributedBlindedPepperDto } from '@app/onboarding/dto/DistributedBlindedPepperDto'
-import { RootError } from '@celo/base/lib/result'
+import { Err, Ok, Result } from '@celo/base/lib/result'
 import { Inject, Injectable } from '@nestjs/common'
 import { ClientProxy } from '@nestjs/microservices'
-import { RelayerResponse } from 'apps/relayer/src/app.controller'
+import { RelayerCmd, RelayerResponse } from 'apps/relayer/src/app.controller'
 import { SignPersonalMessageDto } from 'apps/relayer/src/dto/SignPersonalMessageDto'
 import { SubmitTransactionBatchDto } from 'apps/relayer/src/dto/SubmitTransactionBatchDto'
 import { SubmitTransactionDto } from 'apps/relayer/src/dto/SubmitTransactionDto'
+import { isRight } from 'fp-ts/Either'
+import * as t from 'io-ts'
+import { of, race } from 'rxjs'
+import { catchError, delay, map } from 'rxjs/operators'
 
 export enum RelayerErrorTypes {
   RelayerTimeout = "RelayerTimeout",
-  RelayerCommunicationError = "RelayerCommunicationError"
+  RelayerCommunicationError = "RelayerCommunicationError",
+  RelayerInternalError = "RelayerInternalError"
 }
 
-class RelayerTimeout extends RootError<RelayerErrorTypes.RelayerTimeout> {
-  constructor() {
-    super(RelayerErrorTypes.RelayerTimeout)
+class RelayerTimeout extends MetadataError<RelayerErrorTypes.RelayerTimeout> {
+  constructor(meta: {cmd: RelayerCmd}) {
+    super(RelayerErrorTypes.RelayerTimeout, meta)
   }
 }
 
-class RelayerCommunicationError extends RootError<RelayerErrorTypes.RelayerCommunicationError> {
-  constructor(public readonly message) {
-    super(RelayerErrorTypes.RelayerCommunicationError)
+class RelayerCommunicationError extends MetadataError<RelayerErrorTypes.RelayerCommunicationError> {
+  constructor(meta: {message, cmd}) {
+    super(RelayerErrorTypes.RelayerCommunicationError, meta)
   }
 }
+
+class RelayerInternalError extends MetadataError<RelayerErrorTypes.RelayerInternalError> {
+  constructor(meta: {errorType: string, message: string, metadata: any}) {
+    super(RelayerErrorTypes.RelayerInternalError, meta)
+  }
+}
+
+type RelayerError = RelayerTimeout | RelayerCommunicationError | RelayerInternalError
+type RelayerResult<TResp> = Result<RelayerResponse<TResp>, RelayerError>
 
 @Injectable()
 export class RelayerProxyService {
@@ -34,61 +49,62 @@ export class RelayerProxyService {
 
   async signPersonalMessage(
     input: SignPersonalMessageDto
-  ): Promise<RelayerResponse<string>> {
-    return this.withTimeout(
-      this.client
-        .send({ cmd: `getPhoneNumberIdentifier` }, input)
-        .toPromise()
-    )
+  ): Promise<RelayerResult<string>> {
+    return this.execute(RelayerCmd.SignPersonalMessage, input)
   }
 
   async getPhoneNumberIdentifier(
     input: DistributedBlindedPepperDto
-  ): Promise<RelayerResponse<string>> {
-    return this.withTimeout(
-      this.client
-        .send({ cmd: `getPhoneNumberIdentifier` }, input)
-        .toPromise()
-    )
+  ): Promise<RelayerResult<string>> {
+    return this.execute(RelayerCmd.GetPhoneNumberIdentifier, input)
   }
 
   async submitTransaction(
     input: SubmitTransactionDto
-  ): Promise<RelayerResponse<string>> {
-    return this.withTimeout(
-      this.client
-        .send({ cmd: `submitTransaction` }, input)
-        .toPromise()
-    )
+  ): Promise<RelayerResult<string>> {
+    return this.execute<string>(RelayerCmd.SubmitTransaction, input)
   }
+
 
   async submitTransactionBatch(
     input: SubmitTransactionBatchDto
-  ): Promise<RelayerResponse<string>> {
-    return this.withTimeout(
-      this.client
-        .send({ cmd: `submitTransactionBatch` }, input)
-        .toPromise()
-    )
+  ): Promise<RelayerResult<string>> {
+    return this.execute(RelayerCmd.SubmitTransactionBatch, input)
   }
 
-  private async withTimeout<T>(call: Promise<T>): Promise<T> {
-    try {
-      return Promise.race([
-        call,
-        new Promise<T>((resolve, reject) => {
-          setTimeout(
-            () => reject(new RelayerTimeout()),
-            this.cfg.relayerRpcTimeoutMs
-          )
+  private execute<TResp, TInput = any>(
+    cmd: RelayerCmd,
+    input: TInput,
+  ): Promise<RelayerResult<TResp>> {
+    return race<RelayerResult<TResp>>(
+      of('timeout').pipe(
+        delay(this.cfg.relayerRpcTimeoutMs),
+        map(_ => Err(new RelayerTimeout({cmd})))
+      ),
+      this.client.send<RelayerResponse<TResp>>({cmd}, input).pipe(
+        map((resp) => Ok(resp)),
+        catchError(err => {
+          const res = RelayerErrorPayload.decode(err)
+          if (isRight(res)) {
+            return of(Err(new RelayerInternalError(res.right)))
+          } else {
+            return of(Err(new RelayerCommunicationError({
+              message: err.message,
+              cmd
+            })))
+
+          }
         })
-      ])
-    } catch (e) {
-      if (e.errorType === RelayerErrorTypes.RelayerTimeout) {
-        throw(e)
-      } else {
-        throw(new RelayerCommunicationError(e.message))
-      }
-    }
+      )
+    ).toPromise()
   }
 }
+
+const RelayerErrorPayload = t.type({
+  errorType: t.string,
+  message: t.string,
+  metadata: t.unknown
+})
+
+type RelayerErrorPayload = t.TypeOf<typeof RelayerErrorPayload>
+

--- a/apps/onboarding/src/session/quota.guard.ts
+++ b/apps/onboarding/src/session/quota.guard.ts
@@ -7,10 +7,11 @@ import { Reflector } from '@nestjs/core'
 
 class QuotaExceededError extends ApiError<'QuotaExceededError'> {
   statusCode = 429
+  metadataProps = ['action']
 
-  constructor(meta: {action: TrackedAction}) {
-    super('QuotaExceededError', meta)
-    this.message = `Quota exceeded on ${meta.action}`
+  constructor(readonly action: TrackedAction) {
+    super('QuotaExceededError')
+    this.message = `Quota exceeded on ${action}`
   }
 }
 
@@ -31,7 +32,7 @@ export class QuotaGuard implements CanActivate {
     const session = request.session as Session
     const usage = session.getActionCount(action)
     if (usage >= this.config[action]) {
-      throw new QuotaExceededError({action})
+      throw new QuotaExceededError(action)
     }
     return true
   }

--- a/apps/onboarding/src/session/quota.guard.ts
+++ b/apps/onboarding/src/session/quota.guard.ts
@@ -5,12 +5,12 @@ import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/commo
 import { ConfigType } from '@nestjs/config'
 import { Reflector } from '@nestjs/core'
 
-class QuotaExceededError extends ApiError<'QuotaExceededError', {action: TrackedAction}> {
+class QuotaExceededError extends ApiError<'QuotaExceededError'> {
   statusCode = 429
 
-  constructor(action: TrackedAction) {
-    super('QuotaExceededError', { action })
-    this.message = `Quota exceeded on ${action}`
+  constructor(meta: {action: TrackedAction}) {
+    super('QuotaExceededError', meta)
+    this.message = `Quota exceeded on ${meta.action}`
   }
 }
 
@@ -31,7 +31,7 @@ export class QuotaGuard implements CanActivate {
     const session = request.session as Session
     const usage = session.getActionCount(action)
     if (usage >= this.config[action]) {
-      throw new QuotaExceededError(action)
+      throw new QuotaExceededError({action})
     }
     return true
   }

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -16,16 +16,20 @@ export class WalletNotDeployed extends RootError<WalletErrorType> {
 
 export class InvalidImplementation extends ApiError<WalletErrorType> {
   statusCode = 400
-  constructor(meta: {implementation: string}) {
-    super(WalletErrorType.InvalidImplementation, meta)
+  metadataProps = ['address']
+
+  constructor(readonly address: string) {
+    super(WalletErrorType.InvalidImplementation)
     this.message = "Unexpected MetaTransactionWallet implementation address"
   }
 }
 
 export class InvalidWallet extends ApiError<WalletErrorType> {
   statusCode = 400
-  constructor(meta: {walletError: WalletValidationError}) {
-    super(WalletErrorType.InvalidImplementation, meta)
+  metadataProps = ['reason']
+
+  constructor(readonly reason: WalletValidationError) {
+    super(WalletErrorType.InvalidImplementation)
     this.message = "Invalid wallet"
   }
 }
@@ -41,28 +45,36 @@ export enum MetaTxValidationErrorTypes {
 
 export class InvalidRootMethod extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(meta: {received: string}) {
-    super(MetaTxValidationErrorTypes.InvalidRootMethod, meta)
+  metadataProps = ['method']
+
+  constructor(readonly method: string) {
+    super(MetaTxValidationErrorTypes.InvalidRootMethod)
   }
 }
 
 export class InvalidChildMethod extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(meta: {received: string}) {
-    super(MetaTxValidationErrorTypes.InvalidChildMethod, meta)
+  metadataProps = ['method']
+
+  constructor(readonly method: string) {
+    super(MetaTxValidationErrorTypes.InvalidChildMethod)
   }
 }
 
 export class InvalidDestination extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(meta: {received: string}) {
-    super(MetaTxValidationErrorTypes.InvalidDestination, meta)
+  metadataProps = ['destination']
+
+  constructor(readonly destination: string) {
+    super(MetaTxValidationErrorTypes.InvalidDestination)
   }
 }
 
 export class InputDecodeError extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(public readonly error?: Error) {
+  metadataProps = []
+
+  constructor(readonly error?: Error) {
     super(MetaTxValidationErrorTypes.InputDecodeError)
     this.message = this.error?.message
   }

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -14,18 +14,18 @@ export class WalletNotDeployed extends RootError<WalletErrorType> {
   }
 }
 
-export class InvalidImplementation extends ApiError<WalletErrorType, {implementation: string}> {
+export class InvalidImplementation extends ApiError<WalletErrorType> {
   statusCode = 400
-  constructor(implementation: string) {
-    super(WalletErrorType.InvalidImplementation, { implementation })
+  constructor(meta: {implementation: string}) {
+    super(WalletErrorType.InvalidImplementation, meta)
     this.message = "Unexpected MetaTransactionWallet implementation address"
   }
 }
 
-export class InvalidWallet extends ApiError<WalletErrorType, {error: string}> {
+export class InvalidWallet extends ApiError<WalletErrorType> {
   statusCode = 400
-  constructor(private readonly walletError: WalletValidationError) {
-    super(WalletErrorType.InvalidImplementation, { error: walletError.errorType })
+  constructor(meta: {walletError: WalletValidationError}) {
+    super(WalletErrorType.InvalidImplementation, meta)
     this.message = "Invalid wallet"
   }
 }
@@ -39,24 +39,24 @@ export enum MetaTxValidationErrorTypes {
   InputDecodeError = "InputDecodeError"
 }
 
-export class InvalidRootMethod extends ApiError<MetaTxValidationErrorTypes, {received: string}> {
+export class InvalidRootMethod extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(public readonly received: string) {
-    super(MetaTxValidationErrorTypes.InvalidRootMethod, { received })
+  constructor(meta: {received: string}) {
+    super(MetaTxValidationErrorTypes.InvalidRootMethod, meta)
   }
 }
 
-export class InvalidChildMethod extends ApiError<MetaTxValidationErrorTypes, {received: string}> {
+export class InvalidChildMethod extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(public readonly received: string) {
-    super(MetaTxValidationErrorTypes.InvalidChildMethod, { received })
+  constructor(meta: {received: string}) {
+    super(MetaTxValidationErrorTypes.InvalidChildMethod, meta)
   }
 }
 
-export class InvalidDestination extends ApiError<MetaTxValidationErrorTypes, {received: string}> {
+export class InvalidDestination extends ApiError<MetaTxValidationErrorTypes> {
   statusCode = 400
-  constructor(public readonly received: string) {
-    super(MetaTxValidationErrorTypes.InvalidDestination, { received })
+  constructor(meta: {received: string}) {
+    super(MetaTxValidationErrorTypes.InvalidDestination, meta)
   }
 }
 

--- a/apps/onboarding/src/wallet/wallet.service.spec.ts
+++ b/apps/onboarding/src/wallet/wallet.service.spec.ts
@@ -10,7 +10,7 @@ import { buildMockWeb3Provider } from '@app/onboarding/utils/testing/mock-web3-p
 import { MetaTxValidationErrorTypes, WalletErrorType } from '@app/onboarding/wallet/errors'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
-import { normalizeAddress } from '@celo/base'
+import { normalizeAddress, Ok } from '@celo/base'
 import { ContractKit } from '@celo/contractkit'
 import { toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { MetaTransactionWalletDeployerWrapper } from '@celo/contractkit/lib/wrappers/MetaTransactionWalletDeployer'
@@ -292,7 +292,7 @@ describe("WalletService", () => {
           const submitTxSpy = jest.spyOn(
             relayerSvc,
             'submitTransaction'
-          ).mockResolvedValue({ payload: txHash, relayerAddress: '0x22' })
+          ).mockResolvedValue(Ok({ payload: txHash, relayerAddress: '0x22' }))
 
           const updateSessionSpy = jest.spyOn(
             sessionSvc,
@@ -379,7 +379,7 @@ describe("WalletService", () => {
           const submitTxSpy = jest.spyOn(
             relayerSvc,
             'submitTransaction'
-          ).mockResolvedValue({ payload: txHash, relayerAddress: '0x22' })
+          ).mockResolvedValue(Ok({ payload: txHash, relayerAddress: '0x22' }))
 
           const updateSessionSpy = jest.spyOn(
             sessionSvc,

--- a/apps/onboarding/src/wallet/wallet.service.ts
+++ b/apps/onboarding/src/wallet/wallet.service.ts
@@ -14,7 +14,7 @@ import {
   WalletNotDeployed
 } from '@app/onboarding/wallet/errors'
 import { networkConfig, NetworkConfig } from '@app/utils/config/network.config'
-import { Address, normalizeAddress } from '@celo/base'
+import { Address, normalizeAddress, throwIfError } from '@celo/base'
 import { Err, Ok, Result } from '@celo/base/lib/result'
 import {
   ABI as MetaTxWalletABI,
@@ -162,9 +162,9 @@ export class WalletService {
         impl.methods.initialize(session.externalAccount).encodeABI()
       ).txo
     )
-    const resp = await this.relayerProxyService.submitTransaction({
+    const resp = throwIfError(await this.relayerProxyService.submitTransaction({
       transaction: txn
-    })
+    }))
 
     this.logger.event(EventType.DeployWalletTxSent, {
       txHash: resp.payload,

--- a/apps/onboarding/src/wallet/wallet.service.ts
+++ b/apps/onboarding/src/wallet/wallet.service.ts
@@ -70,7 +70,7 @@ export class WalletService {
     )
 
     if (txWithMatchingDestination.length === 0) {
-      return Err(new InvalidDestination({received: txMetadata.destination}))
+      return Err(new InvalidDestination(txMetadata.destination))
     }
 
     const metaTxMethodId = txMetadata.methodId
@@ -78,7 +78,7 @@ export class WalletService {
       return metaTxMethodId === normalizeMethodId(allowed.methodId)
     })
     if (matchingTx === undefined) {
-      return Err(new InvalidChildMethod({received: metaTxMethodId}))
+      return Err(new InvalidChildMethod(metaTxMethodId))
     }
 
     return Ok(true)
@@ -110,7 +110,7 @@ export class WalletService {
     )
 
     if (valid.ok !== true) {
-      return Err(new InvalidWallet({walletError: valid.error}))
+      return Err(new InvalidWallet(valid.error))
     }
 
     return valid
@@ -147,7 +147,7 @@ export class WalletService {
 
   async deployWallet(session: Session, implementationAddress: string): Promise<Result<string, InvalidImplementation>> {
     if (!this.isValidImplementation(implementationAddress)) {
-      return Err(new InvalidImplementation({implementation: implementationAddress}))
+      return Err(new InvalidImplementation(implementationAddress))
     }
 
     if (this.hasDeployInProgress(session, implementationAddress)) {

--- a/apps/onboarding/src/wallet/wallet.service.ts
+++ b/apps/onboarding/src/wallet/wallet.service.ts
@@ -70,7 +70,7 @@ export class WalletService {
     )
 
     if (txWithMatchingDestination.length === 0) {
-      return Err(new InvalidDestination(txMetadata.destination))
+      return Err(new InvalidDestination({received: txMetadata.destination}))
     }
 
     const metaTxMethodId = txMetadata.methodId
@@ -78,7 +78,7 @@ export class WalletService {
       return metaTxMethodId === normalizeMethodId(allowed.methodId)
     })
     if (matchingTx === undefined) {
-      return Err(new InvalidChildMethod(metaTxMethodId))
+      return Err(new InvalidChildMethod({received: metaTxMethodId}))
     }
 
     return Ok(true)
@@ -110,7 +110,7 @@ export class WalletService {
     )
 
     if (valid.ok !== true) {
-      return Err(new InvalidWallet(valid.error))
+      return Err(new InvalidWallet({walletError: valid.error}))
     }
 
     return valid
@@ -147,7 +147,7 @@ export class WalletService {
 
   async deployWallet(session: Session, implementationAddress: string): Promise<Result<string, InvalidImplementation>> {
     if (!this.isValidImplementation(implementationAddress)) {
-      return Err(new InvalidImplementation(implementationAddress))
+      return Err(new InvalidImplementation({implementation: implementationAddress}))
     }
 
     if (this.hasDeployInProgress(session, implementationAddress)) {

--- a/apps/onboarding/test/app.e2e-spec.ts
+++ b/apps/onboarding/test/app.e2e-spec.ts
@@ -4,7 +4,6 @@ import { DeployWalletDto } from '@app/onboarding/dto/DeployWalletDto'
 import { StartSessionDto } from '@app/onboarding/dto/StartSessionDto'
 import { CaptchaService, CaptchaVerificationFailed } from '@app/onboarding/gateway/captcha/captcha.service'
 import { DeviceCheckService } from '@app/onboarding/gateway/device-check/device-check.service'
-import { GatewayService } from '@app/onboarding/gateway/gateway.service'
 import { RuleID } from '@app/onboarding/gateway/rules/rule'
 import { SafetyNetService } from '@app/onboarding/gateway/safety-net/safety-net.service'
 import { RelayerProxyService } from '@app/onboarding/relayer/relayer_proxy.service'
@@ -93,10 +92,10 @@ describe('AppController (e2e)', () => {
   beforeEach(async () => {
     await manager.queryRunner.startTransaction()
     jest.spyOn(relayerProxyService, 'getPhoneNumberIdentifier').mockResolvedValue(
-      {
+      Ok({
         payload: "abcd1234",
         relayerAddress: "0x0"
-      }
+      })
     )
   })
 
@@ -200,7 +199,10 @@ describe('AppController (e2e)', () => {
           signature = await wallet.signTypedData(eoa, buildLoginTypedData(eoa, captchaToken))
           verifyCaptchaSpy = jest.spyOn(
             captchaService, 'verifyCaptcha'
-          ).mockResolvedValue(Err(new CaptchaVerificationFailed([])))
+          ).mockResolvedValue(Err(new CaptchaVerificationFailed({
+            errorCodes: [],
+            token: ""
+          })))
         })
 
         it('returns a 401', async () => {

--- a/apps/onboarding/test/app.e2e-spec.ts
+++ b/apps/onboarding/test/app.e2e-spec.ts
@@ -199,10 +199,7 @@ describe('AppController (e2e)', () => {
           signature = await wallet.signTypedData(eoa, buildLoginTypedData(eoa, captchaToken))
           verifyCaptchaSpy = jest.spyOn(
             captchaService, 'verifyCaptcha'
-          ).mockResolvedValue(Err(new CaptchaVerificationFailed({
-            errorCodes: [],
-            token: ""
-          })))
+          ).mockResolvedValue(Err(new CaptchaVerificationFailed([], "")))
         })
 
         it('returns a 401', async () => {

--- a/apps/onboarding/test/error.e2e-spec.ts
+++ b/apps/onboarding/test/error.e2e-spec.ts
@@ -18,16 +18,12 @@ class ExampleApiError extends ApiError<'ExampleApiError'> {
   }
 }
 
-interface ExampleMetadata {
-  address: string
-  count: number
-}
-
-class ExampleApiErrorWithMetadata extends ApiError<'ExampleApiError', ExampleMetadata> {
+class ExampleApiErrorWithMetadata extends ApiError<'ExampleApiError'> {
   statusCode = 400
 
-  constructor(address: string, count: number) {
-    super('ExampleApiError', {address, count})
+
+  constructor(meta: {address: string, count: number}) {
+    super('ExampleApiError', meta)
     this.message = 'This is an example error'
   }
 }
@@ -48,7 +44,10 @@ export class ErrorController {
 
   @Get('throwApiErrorWithMetadata')
   async throwApiErrorWithMetadata() {
-    throw new ExampleApiErrorWithMetadata("0x0", 100)
+    throw new ExampleApiErrorWithMetadata({
+      address: "0x0",
+      count: 100
+    })
   }
 
   @Get('throwRootError')

--- a/apps/onboarding/test/error.e2e-spec.ts
+++ b/apps/onboarding/test/error.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { KomenciLoggerModule } from '@app/komenci-logger'
-import { ApiError } from '@app/komenci-logger/errors'
+import { ApiError, ErrorMeta } from '@app/komenci-logger/errors'
 import { ApiErrorFilter } from '@app/komenci-logger/filters/api-error.filter'
 import { RootError } from '@celo/base/lib/result'
 import { Controller, Get } from '@nestjs/common'
@@ -22,8 +22,11 @@ class ExampleApiErrorWithMetadata extends ApiError<'ExampleApiError'> {
   statusCode = 400
 
 
-  constructor(meta: {address: string, count: number}) {
-    super('ExampleApiError', meta)
+  constructor(
+    @ErrorMeta('address') readonly address: string,
+    @ErrorMeta('count') readonly count: number
+  ) {
+    super('ExampleApiError')
     this.message = 'This is an example error'
   }
 }
@@ -44,10 +47,7 @@ export class ErrorController {
 
   @Get('throwApiErrorWithMetadata')
   async throwApiErrorWithMetadata() {
-    throw new ExampleApiErrorWithMetadata({
-      address: "0x0",
-      count: 100
-    })
+    throw new ExampleApiErrorWithMetadata("0x0", 100)
   }
 
   @Get('throwRootError')

--- a/apps/onboarding/test/error.e2e-spec.ts
+++ b/apps/onboarding/test/error.e2e-spec.ts
@@ -1,5 +1,5 @@
 import { KomenciLoggerModule } from '@app/komenci-logger'
-import { ApiError, ErrorMeta } from '@app/komenci-logger/errors'
+import { ApiError } from '@app/komenci-logger/errors'
 import { ApiErrorFilter } from '@app/komenci-logger/filters/api-error.filter'
 import { RootError } from '@celo/base/lib/result'
 import { Controller, Get } from '@nestjs/common'
@@ -11,6 +11,7 @@ const request = require('supertest')
 
 class ExampleApiError extends ApiError<'ExampleApiError'> {
   statusCode = 400
+  metadataProps = []
 
   constructor() {
     super('ExampleApiError')
@@ -20,12 +21,10 @@ class ExampleApiError extends ApiError<'ExampleApiError'> {
 
 class ExampleApiErrorWithMetadata extends ApiError<'ExampleApiError'> {
   statusCode = 400
+  metadataProps = ['address', 'count']
 
 
-  constructor(
-    @ErrorMeta('address') readonly address: string,
-    @ErrorMeta('count') readonly count: number
-  ) {
+  constructor(readonly address: string, readonly count: number) {
     super('ExampleApiError')
     this.message = 'This is an example error'
   }

--- a/apps/relayer/src/app.controller.ts
+++ b/apps/relayer/src/app.controller.ts
@@ -22,8 +22,15 @@ export interface RelayerResponse<T> {
   relayerAddress: string
 }
 
+export enum RelayerCmd {
+  SignPersonalMessage = "signPersonalMessage",
+  GetPhoneNumberIdentifier = "getPhoneNumberIdentifier",
+  SubmitTransaction = "submitTransaction",
+  SubmitTransactionBatch = "submitTransactionBatch",
+}
+
 @Controller()
-@UseFilters(new RpcErrorFilter())
+@UseFilters(RpcErrorFilter)
 export class AppController {
   constructor(
     private readonly odisService: OdisService,
@@ -34,7 +41,7 @@ export class AppController {
     private transactionService: TransactionService,
   ) {}
 
-  @MessagePattern({ cmd: 'signPersonalMessage' })
+  @MessagePattern({ cmd: RelayerCmd.SignPersonalMessage})
   async signPersonalMessage(
     @Body() input: SignPersonalMessageDto
   ): Promise<RelayerResponse<string>> {
@@ -46,38 +53,35 @@ export class AppController {
     )
   }
 
-  @MessagePattern({ cmd: 'getPhoneNumberIdentifier' })
+  @MessagePattern({ cmd: RelayerCmd.GetPhoneNumberIdentifier})
   async getPhoneNumberIdentifier(
     @Body() input: DistributedBlindedPepperDto,
   ): Promise<RelayerResponse<string>> {
     return this.wrapResponse(
       await makeAsyncThrowable(
         this.odisService.getPhoneNumberIdentifier,
-        (error: Error) => new RpcException(error.message)
       )(input)
     )
   }
 
-  @MessagePattern({ cmd: 'submitTransaction' })
+  @MessagePattern({ cmd: RelayerCmd.SubmitTransaction})
   async submitTransaction(
     @Body() input: SubmitTransactionDto
   ): Promise<RelayerResponse<string>> {
     return this.wrapResponse(
       await makeAsyncThrowable(
-        this.transactionService.submitTransaction,
-        (error: Error) => new RpcException(error.message)
+        this.transactionService.submitTransaction
       )(input.transaction)
     )
   }
 
-  @MessagePattern({ cmd: 'submitTransactionBatch' })
+  @MessagePattern({ cmd: RelayerCmd.SubmitTransactionBatch })
   async submitTransactionBatch(
     @Body() input: SubmitTransactionBatchDto
   ): Promise<RelayerResponse<string>> {
     return this.wrapResponse(
       await makeAsyncThrowable(
          this.transactionService.submitTransaction,
-        (error: Error) => new RpcException(error.message)
       )(
         toRawTransaction(
           this.metaTxWallet.executeTransactions(

--- a/apps/relayer/src/app.module.ts
+++ b/apps/relayer/src/app.module.ts
@@ -2,6 +2,7 @@ import { BlockchainModule, ContractsModule } from '@app/blockchain'
 import { NodeProviderType } from '@app/blockchain/config/node.config'
 import { WalletConfig, walletConfig } from '@app/blockchain/config/wallet.config'
 import { KomenciLoggerModule } from '@app/komenci-logger'
+import { RpcErrorFilter } from '@app/komenci-logger/filters/rpc-error.filter'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
 import { HttpModule, Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
@@ -70,6 +71,7 @@ import { metaTransactionWalletProvider } from './contracts/MetaTransactionWallet
   ],
   controllers: [AppController],
   providers: [
+    RpcErrorFilter,
     OdisService,
     TransactionService,
     BalanceService,

--- a/apps/relayer/src/chain/balance.service.ts
+++ b/apps/relayer/src/chain/balance.service.ts
@@ -4,8 +4,7 @@ import { ContractKit } from '@celo/contractkit'
 import { GoldTokenWrapper } from '@celo/contractkit/lib/wrappers/GoldTokenWrapper'
 import { MetaTransactionWalletWrapper } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper'
-import { Inject, Injectable, OnModuleDestroy, OnModuleInit } from '@nestjs/common'
-import { appConfig, AppConfig } from 'apps/relayer/src/config/app.config'
+import { Inject, Injectable, OnModuleInit } from '@nestjs/common'
 import BigNumber from 'bignumber.js'
 
 @Injectable()
@@ -38,8 +37,8 @@ export class BalanceService implements OnModuleInit {
     const exp = new BigNumber(10).pow(18)
 
     this.logger.event(EventType.RelayerBalance, {
-      cUSD: cUSDBalance.div(exp).toFixed(),
-      celo: celoBalance.div(exp).toFixed(),
+      cUSD: parseFloat(cUSDBalance.div(exp).toFixed()),
+      celo: parseFloat(celoBalance.div(exp).toFixed()),
     })
   }
 }

--- a/apps/relayer/src/chain/errors.ts
+++ b/apps/relayer/src/chain/errors.ts
@@ -9,17 +9,23 @@ export enum ChainErrorTypes {
 export class TxSubmitError extends MetadataError<ChainErrorTypes.TxSubmitError> {
   constructor(
     public readonly err: Error,
-    meta: {message: string, tx: RawTransaction}
+    public readonly metadata: {
+      message: string,
+      tx: RawTransaction
+    }
   ) {
-    super(ChainErrorTypes.TxSubmitError, meta)
+    super(ChainErrorTypes.TxSubmitError)
   }
 }
 
 export class TxDeadletterError extends MetadataError<ChainErrorTypes.TxDeadletterError> {
   constructor(
     public readonly err: Error,
-    meta: {message: string, txHash: string}
+    public readonly metadata: {
+      message: string,
+      txHash: string
+    }
   ) {
-    super(ChainErrorTypes.TxDeadletterError, meta)
+    super(ChainErrorTypes.TxDeadletterError)
   }
 }

--- a/apps/relayer/src/chain/errors.ts
+++ b/apps/relayer/src/chain/errors.ts
@@ -7,25 +7,19 @@ export enum ChainErrorTypes {
 }
 
 export class TxSubmitError extends MetadataError<ChainErrorTypes.TxSubmitError> {
-  constructor(
-    public readonly err: Error,
-    public readonly metadata: {
-      message: string,
-      tx: RawTransaction
-    }
-  ) {
+  metadataProps = ['tx']
+
+  constructor(public readonly err: Error, readonly tx: RawTransaction) {
     super(ChainErrorTypes.TxSubmitError)
+    this.message = `TxSubmitError: ${err.message}`
   }
 }
 
 export class TxDeadletterError extends MetadataError<ChainErrorTypes.TxDeadletterError> {
-  constructor(
-    public readonly err: Error,
-    public readonly metadata: {
-      message: string,
-      txHash: string
-    }
-  ) {
+  metadataProps = ['txHash']
+
+  constructor(readonly err: Error, readonly txHash: string) {
     super(ChainErrorTypes.TxDeadletterError)
+    this.message = `TxSubmitError: ${err.message}`
   }
 }

--- a/apps/relayer/src/chain/errors.ts
+++ b/apps/relayer/src/chain/errors.ts
@@ -1,0 +1,25 @@
+import { MetadataError } from '@app/komenci-logger/errors'
+import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+
+export enum ChainErrorTypes {
+  TxSubmitError = "TxSubmitError",
+  TxDeadletterError = "TxDeadletterError"
+}
+
+export class TxSubmitError extends MetadataError<ChainErrorTypes.TxSubmitError> {
+  constructor(
+    public readonly err: Error,
+    meta: {message: string, tx: RawTransaction}
+  ) {
+    super(ChainErrorTypes.TxSubmitError, meta)
+  }
+}
+
+export class TxDeadletterError extends MetadataError<ChainErrorTypes.TxDeadletterError> {
+  constructor(
+    public readonly err: Error,
+    meta: {message: string, txHash: string}
+  ) {
+    super(ChainErrorTypes.TxDeadletterError, meta)
+  }
+}

--- a/apps/relayer/src/chain/transaction.service.ts
+++ b/apps/relayer/src/chain/transaction.service.ts
@@ -7,6 +7,7 @@ import {
   walletConfig
 } from '@app/blockchain/config/wallet.config'
 import { EventType, KomenciLoggerService } from '@app/komenci-logger'
+import { sleep } from '@celo/base'
 import { Err, Ok, Result } from '@celo/base/lib/result'
 import { ContractKit } from '@celo/contractkit'
 import { toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
@@ -17,8 +18,8 @@ import {
   OnModuleInit
 } from '@nestjs/common'
 import { BalanceService } from 'apps/relayer/src/chain/balance.service'
+import { TxDeadletterError, TxSubmitError } from 'apps/relayer/src/chain/errors'
 import { RawTransactionDto } from 'apps/relayer/src/dto/RawTransactionDto'
-import exp from 'constants'
 import Web3 from 'web3'
 import { Transaction } from 'web3-core'
 import { TransactionObject } from 'web3-eth'
@@ -62,9 +63,9 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
 
   submitTransaction = async (
     tx: RawTransactionDto
-  ): Promise<Result<string, any>> => {
+  ): Promise<Result<string, TxSubmitError>> => {
     let tries = 0
-    while (++tries < 3) {
+    while (++tries <= 3) {
       try {
         const result = await this.kit.sendTransaction({
           to: tx.destination,
@@ -93,11 +94,13 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
         return Ok(txHash)
       } catch (e) {
         if (tries === 3) {
-          this.logger.event(EventType.TxSubmitFailure, {
-            destination: tx.destination
+          const err = new TxSubmitError(e, {
+            message: e.message,
+            tx: tx
           })
 
-          return Err(e)
+          // this.logger.error(err)
+          return Err(err)
         }
       }
     }
@@ -175,13 +178,11 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
         nonce: tx.nonce
       })
     } catch (e) {
-      this.logger.error(
-        'Could not dead-letter transaction',
-        '',
-        {
-          txHash: tx.hash,
-          nonce: tx.nonce
+      const err = new TxDeadletterError(e, {
+        message: e.message,
+        txHash: tx.hash
       })
+      this.logger.error(err)
     }
   }
 

--- a/apps/relayer/src/chain/transaction.service.ts
+++ b/apps/relayer/src/chain/transaction.service.ts
@@ -94,11 +94,7 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
         return Ok(txHash)
       } catch (e) {
         if (tries === 3) {
-          const err = new TxSubmitError(e, {
-            message: e.message,
-            tx: tx
-          })
-
+          const err = new TxSubmitError(e, tx)
           // this.logger.error(err)
           return Err(err)
         }
@@ -178,10 +174,7 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
         nonce: tx.nonce
       })
     } catch (e) {
-      const err = new TxDeadletterError(e, {
-        message: e.message,
-        txHash: tx.hash
-      })
+      const err = new TxDeadletterError(e, tx.hash)
       this.logger.error(err)
     }
   }

--- a/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
+++ b/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
@@ -21,8 +21,10 @@ class RelayerNotRegisteredError extends RootError<RelayerMTWErrorTypes.NotRegist
 }
 
 class NoMTWError extends MetadataError<RelayerMTWErrorTypes.NoMTW> {
-  constructor(meta: {configAddress: string}) {
-    super(RelayerMTWErrorTypes.NoMTW, meta)
+  constructor(
+    public readonly metadata: {configAddress: string}
+  ) {
+    super(RelayerMTWErrorTypes.NoMTW)
     this.message = `Relayer doesn't have a valid associated MTW in config`
   }
 }

--- a/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
+++ b/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
@@ -10,7 +10,7 @@ import { isValidAddress } from '@celo/utils/lib/address'
 
 enum RelayerMTWErrorTypes {
   NotRegister = "RelayerNotRegistered",
-  NoMTW = "NoMTW"
+  InvalidMTW = "InvalidMTW"
 }
 
 class RelayerNotRegisteredError extends RootError<RelayerMTWErrorTypes.NotRegister> {
@@ -20,11 +20,11 @@ class RelayerNotRegisteredError extends RootError<RelayerMTWErrorTypes.NotRegist
   }
 }
 
-class NoMTWError extends MetadataError<RelayerMTWErrorTypes.NoMTW> {
-  constructor(
-    public readonly metadata: {configAddress: string}
-  ) {
-    super(RelayerMTWErrorTypes.NoMTW)
+class InvalidMTWError extends MetadataError<RelayerMTWErrorTypes.InvalidMTW> {
+  metadataProps = ['address']
+
+  constructor(readonly address: string) {
+    super(RelayerMTWErrorTypes.InvalidMTW)
     this.message = `Relayer doesn't have a valid associated MTW in config`
   }
 }
@@ -55,7 +55,7 @@ export const metaTransactionWalletProvider = {
         relayer.metaTransactionWallet
       )
     } else {
-      logger.logAndThrow(new NoMTWError({configAddress: relayer.metaTransactionWallet}))
+      logger.logAndThrow(new InvalidMTWError(relayer.metaTransactionWallet))
     }
   },
   inject: [

--- a/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
+++ b/apps/relayer/src/contracts/MetaTransactionWallet.contract.ts
@@ -20,11 +20,9 @@ class RelayerNotRegisteredError extends RootError<RelayerMTWErrorTypes.NotRegist
   }
 }
 
-class NoMTWError extends MetadataError<RelayerMTWErrorTypes.NoMTW, {configAddress: string}> {
-  constructor(private mtwAddress: string) {
-    super(RelayerMTWErrorTypes.NoMTW, {
-      configAddress: mtwAddress
-    })
+class NoMTWError extends MetadataError<RelayerMTWErrorTypes.NoMTW> {
+  constructor(meta: {configAddress: string}) {
+    super(RelayerMTWErrorTypes.NoMTW, meta)
     this.message = `Relayer doesn't have a valid associated MTW in config`
   }
 }
@@ -55,7 +53,7 @@ export const metaTransactionWalletProvider = {
         relayer.metaTransactionWallet
       )
     } else {
-      logger.logAndThrow(new NoMTWError(relayer.metaTransactionWallet))
+      logger.logAndThrow(new NoMTWError({configAddress: relayer.metaTransactionWallet}))
     }
   },
   inject: [

--- a/apps/relayer/src/main.ts
+++ b/apps/relayer/src/main.ts
@@ -8,7 +8,7 @@ import { AppConfig } from './config/app.config'
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
-    logger: process.env.NODE_ENV !== "production"
+    logger: process.env.NODE_ENV === "production" ? false : undefined
   })
 
   const appConfig = app.get(ConfigService).get<AppConfig>('app')

--- a/apps/relayer/src/main.ts
+++ b/apps/relayer/src/main.ts
@@ -7,7 +7,10 @@ import { AppModule } from './app.module'
 import { AppConfig } from './config/app.config'
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule)
+  const app = await NestFactory.create(AppModule, {
+    logger: process.env.NODE_ENV !== "production"
+  })
+
   const appConfig = app.get(ConfigService).get<AppConfig>('app')
   app.connectMicroservice<TcpOptions>({
     transport: Transport.TCP,

--- a/libs/blockchain/src/contracts.module.ts
+++ b/libs/blockchain/src/contracts.module.ts
@@ -24,7 +24,7 @@ const metaTransactionWalletDeployer = {
     )
 
     logger.log({
-      message: 'Initialized MetaTransactionWalletDeployer',
+      msg: 'Initialized MetaTransactionWalletDeployer',
       address: options.deployerAddress,
     })
 

--- a/libs/komenci-logger/src/errors.ts
+++ b/libs/komenci-logger/src/errors.ts
@@ -25,7 +25,14 @@ export abstract class MetadataError<TError> extends RootError<TError> {
   }
 }
 
-export abstract class ApiError<TError, TMetadata extends object = any> extends MetadataError<TError> {
+interface ApiErrorPayload<TError> {
+  statusCode: number
+  errorType: TError
+  message: string,
+  metadata?: any
+}
+
+export abstract class ApiError<TError> extends MetadataError<TError> {
   [errorTypeSymbol] = apiErrorSymbol
   abstract statusCode: number
 
@@ -36,12 +43,17 @@ export abstract class ApiError<TError, TMetadata extends object = any> extends M
   }
 
   toJSON = () => {
-    return {
+    const payload: ApiErrorPayload<TError> = {
       statusCode: this.statusCode,
       errorType: this.errorType,
       message: this.message,
-      metadata: this.getMetadata()
     }
+
+    if (this.metadataProps.length > 0) {
+      payload.metadata = this.getMetadata()
+    }
+
+    return payload
   }
 }
 
@@ -53,7 +65,7 @@ export const isMetadataError = (error: any): error is MetadataError<any> => {
   return error[errorTypeSymbol] === metadataErrorSymbol
 }
 
-export const isApiError = (error: any): error is ApiError<any, any> => {
+export const isApiError = (error: any): error is ApiError<any> => {
   return error[errorTypeSymbol] === apiErrorSymbol
 }
 

--- a/libs/komenci-logger/src/errors.ts
+++ b/libs/komenci-logger/src/errors.ts
@@ -4,7 +4,7 @@ export const errorTypeSymbol = Symbol('errorType')
 export const apiErrorSymbol = Symbol('ApiError')
 export const metadataErrorSymbol = Symbol('MetadataError')
 
-export abstract class MetadataError<TError, TMetadata> extends RootError<TError> {
+export abstract class MetadataError<TError, TMetadata extends object = {}> extends RootError<TError> {
   [errorTypeSymbol] = metadataErrorSymbol
 
   protected constructor(
@@ -15,7 +15,7 @@ export abstract class MetadataError<TError, TMetadata> extends RootError<TError>
   }
 }
 
-export abstract class ApiError<TError, TMetadata = never> extends MetadataError<TError, TMetadata> {
+export abstract class ApiError<TError, TMetadata extends object = {}> extends MetadataError<TError, TMetadata> {
   [errorTypeSymbol] = apiErrorSymbol
   abstract statusCode: number
 

--- a/libs/komenci-logger/src/errors.ts
+++ b/libs/komenci-logger/src/errors.ts
@@ -36,14 +36,15 @@ export abstract class ApiError<TError, TMetadata extends object = {}> extends Me
   }
 }
 
-export const isRootError = (error: any) => {
+export const isRootError = (error: any): error is RootError<any> => {
   return error.errorType !== undefined
 }
 
-export const isMetadataError = (error: any) => {
+export const isMetadataError = (error: any): error is MetadataError<any, any> => {
   return error[errorTypeSymbol] === metadataErrorSymbol
 }
 
-export const isApiError = (error: any) => {
+export const isApiError = (error: any): error is ApiError<any, any> => {
   return error[errorTypeSymbol] === apiErrorSymbol
 }
+

--- a/libs/komenci-logger/src/errors.ts
+++ b/libs/komenci-logger/src/errors.ts
@@ -4,26 +4,29 @@ export const errorTypeSymbol = Symbol('errorType')
 export const apiErrorSymbol = Symbol('ApiError')
 export const metadataErrorSymbol = Symbol('MetadataError')
 
-export abstract class MetadataError<TError, TMetadata extends object = {}> extends RootError<TError> {
+export abstract class MetadataError<TError, TMetadata = object> extends RootError<TError> {
   [errorTypeSymbol] = metadataErrorSymbol
+
+  public abstract readonly metadata: TMetadata
 
   protected constructor(
     errorType: TError,
-    public readonly metadata: TMetadata
   ) {
     super(errorType)
   }
 }
 
-export abstract class ApiError<TError, TMetadata extends object = {}> extends MetadataError<TError, TMetadata> {
+export abstract class ApiError<TError, TMetadata extends object = any> extends MetadataError<TError, TMetadata> {
   [errorTypeSymbol] = apiErrorSymbol
   abstract statusCode: number
+  public readonly metadata: TMetadata
 
   protected constructor(
     errorType: TError,
     metadata?: TMetadata
   ) {
-    super(errorType, metadata)
+    super(errorType)
+    this.metadata = metadata
   }
 
   toJSON = () => {
@@ -40,7 +43,7 @@ export const isRootError = (error: any): error is RootError<any> => {
   return error.errorType !== undefined
 }
 
-export const isMetadataError = (error: any): error is MetadataError<any, any> => {
+export const isMetadataError = (error: any): error is MetadataError<any> => {
   return error[errorTypeSymbol] === metadataErrorSymbol
 }
 

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -12,7 +12,6 @@ export enum EventType {
   // Relayer service events:
   RelayerMTWInit = 'RelayerMTWInit',
   TxSubmitted = 'TxSubmitted',
-  TxSubmitFailure = 'TxSubmitFailure',
   TxConfirmed = 'TxConfirmed',
   TxTimeout = 'TxTimeout',
   RuleVerified = 'RuleVerified',
@@ -52,9 +51,6 @@ export type EventPayload = {
     mtwAddress: string
   }
   [EventType.TxSubmitted]: TxEvent
-  [EventType.TxSubmitFailure]: {
-    destination: string
-  }
   [EventType.TxConfirmed]: TxEvent & {
     isRevert: boolean
     gasPrice: number

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -29,8 +29,7 @@ export type EventPayload = {
   [EventType.SessionStartFailure]: SessionEvent
   [EventType.RuleVerified]: AccountEvent & {
     ruleId: string
-    metaData?: Record<string, unknown>
-    result: Result<boolean, any>
+    result: boolean
   }
   [EventType.DeployWalletTxSent]: SessionEvent & {
     txHash: string

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -63,8 +63,8 @@ export type EventPayload = {
     gasCost: number
   }
   [EventType.RelayerBalance]: {
-    cUSD: string
-    celo: string
+    cUSD: number
+    celo: number
   }
   [EventType.TxTimeout]: TxEvent & {
     deadLetterHash: string,

--- a/libs/komenci-logger/src/filters/rpc-error.filter.ts
+++ b/libs/komenci-logger/src/filters/rpc-error.filter.ts
@@ -7,7 +7,7 @@ import {
   Inject,
 } from '@nestjs/common'
 import { BaseRpcExceptionFilter } from '@nestjs/microservices'
-import { Observable, throwError as _throw } from 'rxjs';
+import { Observable, throwError as _throw } from 'rxjs'
 
 @Catch()
 export class RpcErrorFilter extends BaseRpcExceptionFilter {

--- a/libs/komenci-logger/src/filters/rpc-error.filter.ts
+++ b/libs/komenci-logger/src/filters/rpc-error.filter.ts
@@ -21,7 +21,7 @@ export class RpcErrorFilter extends BaseRpcExceptionFilter {
       return _throw({
         errorType: err.errorType,
         message: err.message,
-        metadata: err.metadata
+        metadata: err.getMetadata()
       })
     } else if (isRootError(err)) {
       return _throw({

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -1,7 +1,7 @@
 import { ApiError, isApiError, isMetadataError, isRootError, MetadataError } from '@app/komenci-logger/errors'
 import { RootError } from '@celo/base'
 import { Injectable, LoggerService } from '@nestjs/common'
-import { Logger } from "nestjs-pino"
+import { PinoLogger } from 'nestjs-pino'
 
 import { EventPayload } from '@app/komenci-logger/events'
 
@@ -11,14 +11,14 @@ export interface KomenciLogger extends LoggerService {
 
 @Injectable()
 export class KomenciLoggerService implements KomenciLogger {
-  constructor(private readonly logger: Logger) {}
+  constructor(private readonly logger: PinoLogger) {}
 
   log(message: any, context?: any, ...args): void {
-    this.logger.log(message, context, ...args)
+    this.logger.info(message, context, ...args)
   }
 
   verbose(message: any, context?: any, ...args): void {
-    this.logger.verbose(message, context, ...args)
+    this.logger.trace(message, context, ...args)
   }
 
   debug(message: any, context?: any, ...args): void {
@@ -47,39 +47,42 @@ export class KomenciLoggerService implements KomenciLogger {
   }
 
   event<K extends keyof EventPayload>(eventType: K, payload: EventPayload[K]): void {
-    this.log(eventType, payload)
+    this.log({
+      event: eventType,
+      payload
+    }, eventType)
   }
 
 
   private logApiError(error: ApiError<any, any>): void {
-    this.logger.error(
+    this.logger.error({
+        error: error.errorType,
+        payload: error.metadata
+      },
       error.message,
       error.stack,
-      {
-        type: error.errorType,
-        ...error.metadata
-      },
+      "KomenciLoggerService",
     )
   }
 
   private logRootError(error: RootError<any>): void {
-    this.error(
+    this.error({
+        error: error.errorType,
+      },
       error.message,
       error.stack,
-      {
-        type: error.errorType,
-      },
+      "KomenciLoggerService",
     )
   }
 
   private logMetadataError(error: MetadataError<any, any>): void {
-    this.logger.error(
+    this.logger.error({
+        error: error.errorType,
+        payload: error.metadata
+      },
       error.message,
       error.stack,
-      {
-        type: error.errorType,
-        ...error.metadata
-      },
+      "KomenciLoggerService",
     )
   }
 }

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -33,6 +33,7 @@ export class KomenciLoggerService implements KomenciLogger {
     if (isApiError(message)) {
       this.logApiError(message)
     } else if (isMetadataError(message)) {
+      console.log(message)
       this.logMetadataError(message)
     } else if (isRootError(message)) {
       this.logRootError(message)
@@ -57,7 +58,7 @@ export class KomenciLoggerService implements KomenciLogger {
   private logApiError(error: ApiError<any, any>): void {
     this.logger.error({
         error: error.errorType,
-        payload: error.metadata
+        payload: error.getMetadata()
       },
       error.message,
       error.stack,
@@ -75,10 +76,10 @@ export class KomenciLoggerService implements KomenciLogger {
     )
   }
 
-  private logMetadataError(error: MetadataError<any, any>): void {
+  private logMetadataError(error: MetadataError<any>): void {
     this.logger.error({
         error: error.errorType,
-        payload: error.metadata
+        payload: error.getMetadata()
       },
       error.message,
       error.stack,

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -33,7 +33,6 @@ export class KomenciLoggerService implements KomenciLogger {
     if (isApiError(message)) {
       this.logApiError(message)
     } else if (isMetadataError(message)) {
-      console.log(message)
       this.logMetadataError(message)
     } else if (isRootError(message)) {
       this.logRootError(message)

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -55,7 +55,7 @@ export class KomenciLoggerService implements KomenciLogger {
   }
 
 
-  private logApiError(error: ApiError<any, any>): void {
+  private logApiError(error: ApiError<any>): void {
     this.logger.error({
         error: error.errorType,
         payload: error.getMetadata()

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "pino-noir": "^2.2.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
+    "rxjs": "^6.6.3",
     "typeorm": "^0.2.26",
     "uuid": "^8.3.0",
     "web3": "1.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10177,6 +10177,13 @@ rxjs@^6.5.3, rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
+rxjs@^6.6.3:
+  version "6.6.3"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
+  integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+  dependencies:
+    tslib "^1.9.0"
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"


### PR DESCRIPTION
There were still a couple of issues with how we were logging because of a mishap with nestjs-pino.
This is now addressed by relying on the `PinoLogger`.

Specifically: 
- All events log `event: "EventName"` and `payload: {...}` for metadata
- All errors log `error: "ErrorType"` and `payload: {...}`  for metadata
- There a few lines of unstructured log at the beginning which are now omitted when running in production by disabling the nest level logger. 
- Relayer proxy refactor to improve error handling and cleanup usage as well