### PR TITLE
Datacenter Affinity

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,22 @@
           "port": 9229
         },
         {
+          "name": "Onboarding Unit Tests",
+          "type": "node",
+          "request": "launch",
+          "runtimeArgs": [
+            "--inspect-brk",
+            "${workspaceRoot}/node_modules/.bin/jest",
+            "--rootDir",
+            "${workspaceFolder}",
+            "--runInBand",
+            "${workspaceFolder}/apps/onboarding/src/**/*.spec.ts",
+          ],
+          "console": "integratedTerminal",
+          "internalConsoleOptions": "neverOpen",
+          "port": 9229
+        },
+        {
           "name": "Onboarding E2E Tests",
           "type": "node",
           "request": "launch",

--- a/apps/onboarding/src/app.controller.spec.ts
+++ b/apps/onboarding/src/app.controller.spec.ts
@@ -101,7 +101,7 @@ describe('AppController', () => {
         expect(sessionFindOrCreate).toHaveBeenCalledWith(payload.externalAccount)
         expect(jwtService.verify(result.token)).toBeTruthy()
         expect(jwtService.decode(result.token)).toMatchObject({sessionId: session.id})
-        expect(result.callbackHostname).toBe('localhost')
+        expect(result.callbackUrl).toBe('http://localhost')
       })
     })
 

--- a/apps/onboarding/src/app.controller.spec.ts
+++ b/apps/onboarding/src/app.controller.spec.ts
@@ -101,6 +101,7 @@ describe('AppController', () => {
         expect(sessionFindOrCreate).toHaveBeenCalledWith(payload.externalAccount)
         expect(jwtService.verify(result.token)).toBeTruthy()
         expect(jwtService.decode(result.token)).toMatchObject({sessionId: session.id})
+        expect(result.callbackHostname).toBe('localhost')
       })
     })
 

--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -49,7 +49,7 @@ interface CheckSessionResponse {
 
 interface StartSessionResponse {
   token: string
-  callbackHostname: string
+  callbackUrl: string
 }
 
 @Controller("v1")
@@ -97,7 +97,7 @@ export class AppController {
         sessionId: response.sessionId
       })
 
-      return { token: response.token, callbackHostname: this.appCfg.callbackHostname }
+      return { token: response.token, callbackUrl: this.appCfg.callbackUrl }
     } else {
       throw new UnauthorizedException()
     }

--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -20,6 +20,7 @@ import { SessionService } from 'apps/onboarding/src/session/session.service'
 import { SubmitMetaTransactionDto } from 'apps/relayer/src/dto/SubmitMetaTransactionDto'
 
 import { AuthService } from './auth/auth.service'
+import { appConfig, AppConfig } from './config/app.config'
 import { DistributedBlindedPepperDto } from './dto/DistributedBlindedPepperDto'
 import { StartSessionDto } from './dto/StartSessionDto'
 import { GatewayService } from './gateway/gateway.service'
@@ -46,6 +47,11 @@ interface CheckSessionResponse {
   metaTxWalletAddress?: string
 }
 
+interface StartSessionResponse {
+  token: string
+  callbackHostname: string
+}
+
 @Controller("v1")
 export class AppController {
   // Cache for the allowed metaTx filter
@@ -61,6 +67,8 @@ export class AppController {
     private readonly contractKit: ContractKit,
     @Inject(networkConfig.KEY)
     private readonly networkCfg: NetworkConfig,
+    @Inject(appConfig.KEY)
+    private readonly appCfg: AppConfig,
     private readonly logger: KomenciLoggerService
 ) {}
 
@@ -78,7 +86,7 @@ export class AppController {
   async startSession(
     @Body() startSessionDto: StartSessionDto,
     @Req() req
-  ): Promise<{ token: string }> {
+  ): Promise<StartSessionResponse> {
     if ((await this.gatewayService.verify(startSessionDto, req)) === true) {
       const response = await this.authService.startSession(
         startSessionDto.externalAccount
@@ -89,7 +97,7 @@ export class AppController {
         sessionId: response.sessionId
       })
 
-      return { token: response.token }
+      return { token: response.token, callbackHostname: this.appCfg.callbackHostname }
     } else {
       throw new UnauthorizedException()
     }

--- a/apps/onboarding/src/config/app.config.ts
+++ b/apps/onboarding/src/config/app.config.ts
@@ -9,7 +9,8 @@ export const appConfig = registerAs('app', () => ({
   // This feature should be enabled at a later date after we deploy a
   // new version of Attestations.sol
   useAttestationGuards: process.env.USE_ATTESTATION_GUARDS === 'true',
-  relayerRpcTimeoutMs: parseInt(process.env.RELAYER_RPC_TIMEOUT_MS, 10) || 5000
+  relayerRpcTimeoutMs: parseInt(process.env.RELAYER_RPC_TIMEOUT_MS, 10) || 5000,
+  callbackHostname: process.env.PUBLIC_HOSTNAME || 'localhost'
 }))
 
 export type AppConfig = ConfigType<typeof appConfig>

--- a/apps/onboarding/src/config/app.config.ts
+++ b/apps/onboarding/src/config/app.config.ts
@@ -10,7 +10,7 @@ export const appConfig = registerAs('app', () => ({
   // new version of Attestations.sol
   useAttestationGuards: process.env.USE_ATTESTATION_GUARDS === 'true',
   relayerRpcTimeoutMs: parseInt(process.env.RELAYER_RPC_TIMEOUT_MS, 10) || 5000,
-  callbackHostname: process.env.PUBLIC_HOSTNAME || 'localhost'
+  callbackUrl: process.env.PUBLIC_URL || 'http://localhost'
 }))
 
 export type AppConfig = ConfigType<typeof appConfig>


### PR DESCRIPTION
## What
Return callbackHostname in startSession response

## Why
When we have multiple instance of Komenci deployed, we need the client to make all subsequent calls to the same datacenter since the user's session is stored there. [Here is the follow up PR with changes to KomenciKit](https://github.com/celo-org/celo-monorepo/pull/5755).