### PR TITLE
Add CUSD transfer to approved meta-txs

### DIFF
--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -311,6 +311,10 @@ export class AppController {
           methodId: cUSD.methodIds.approve
         },
         {
+          destination: cUSD.address,
+          methodId: cUSD.methodIds.transfer
+        },
+        {
           destination: escrow.address,
           methodId: escrow.methodIds.withdraw
         }


### PR DESCRIPTION
This PR adds `CUSD.transfer` to the approved list of meta-txs that can be submitted by clients.

This is needed so that escrow withdrawals can be transferred out of the MTW and into the corresponding EOA.