### PR TITLE
Change to two step build to avoid disk space issue

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -22,14 +22,14 @@ jobs:
       id: celo-monorepo-commit
       run: echo "::set-output name=commit::$(git submodule status | awk '{print $1}')"
 
-    - name: Ensure build image exists
+    - name: Build or pull base image
       id: build-celo-monorepo-base-image
       run: |
         if docker pull celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} ; then
           echo "Image found"
         else
           docker build -f Dockerfile.monorepo .\
-            -t celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
+            -t celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} \
             -t celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
           docker push celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
         fi

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,17 +37,8 @@ jobs:
     - name: Build image
       id: build-app-image
       run: |
-        docker pull celotestnet.azurecr.io/komenci/komenci:latest
         docker build .\
             -t celotestnet.azurecr.io/komenci/komenci:${{ github.sha }} \
-            -t celotestnet.azurecr.io/komenci/komenci:latest \
             --build-arg MONORERPO_BUILD_VERSION=${{ steps.celo-monorepo-commit.outputs.commit }}
 
-
-
-        docker tag komenci
         docker push celotestnet.azurecr.io/komenci/komenci:${{ github.sha }}
-
-        docker tag komenci celotestnet.azurecr.io/komenci/komenci:latest
-        docker push celotestnet.azurecr.io/komenci/komenci:latest
-

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,6 +26,7 @@ jobs:
       id: build-celo-monorepo-base-image
       run: |
         if docker pull celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} ; then
+          docker tag celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} celo-monorerpo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
           echo "Image found"
         else
           docker build -f Dockerfile.monorepo .\

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -18,13 +18,34 @@ jobs:
         username: ${{ secrets.ACR_USERNAME }}
         password: ${{ secrets.ACR_PASSWORD }}
 
-    - run: |
+    - name: Get celo-monorepo commit
+      id: celo-monorepo-commit
+      run: echo "::set-output name=commit::$(git submodule status | awk '{print $1}')"
+
+    - name: Ensure build image exists
+      id: build-image
+      run: |
+        if docker pull celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} ; then
+          echo "Image found"
+        else
+          docker build -f Dockerfile.monorepo .\
+            -t celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
+            -t celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
+          docker push celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
+        fi
+
+    - name: Build image
+      id: build-image
+      run: |
         docker pull celotestnet.azurecr.io/komenci/komenci:latest
         docker build .\
-            -t komenci \
-            --cache-from celotestnet.azurecr.io/komenci/komenci:latest \
+            -t celotestnet.azurecr.io/komenci/komenci:${{ github.sha }} \
+            -t celotestnet.azurecr.io/komenci/komenci:latest \
+            --build-arg MONORERPO_BUILD_VERSION=${{ steps.celo-monorepo-commit.outputs.commit }}
 
-        docker tag komenci celotestnet.azurecr.io/komenci/komenci:${{ github.sha }}
+
+
+        docker tag komenci
         docker push celotestnet.azurecr.io/komenci/komenci:${{ github.sha }}
 
         docker tag komenci celotestnet.azurecr.io/komenci/komenci:latest

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -23,7 +23,7 @@ jobs:
       run: echo "::set-output name=commit::$(git submodule status | awk '{print $1}')"
 
     - name: Ensure build image exists
-      id: build-image
+      id: build-celo-monorepo-base-image
       run: |
         if docker pull celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} ; then
           echo "Image found"
@@ -35,7 +35,7 @@ jobs:
         fi
 
     - name: Build image
-      id: build-image
+      id: build-app-image
       run: |
         docker pull celotestnet.azurecr.io/komenci/komenci:latest
         docker build .\

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -26,7 +26,7 @@ jobs:
       id: build-celo-monorepo-base-image
       run: |
         if docker pull celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} ; then
-          docker tag celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} celo-monorerpo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
+          docker tag celotestnet.azurecr.io/komenci/celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }} celo-monorepo-build-base:${{ steps.celo-monorepo-commit.outputs.commit }}
           echo "Image found"
         else
           docker build -f Dockerfile.monorepo .\

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,5 @@
-FROM node:10
-
-RUN apt update -y && apt install -y \
-      bash\
-      g++\
-      gcc\
-      git\
-      libsecret-1-dev\
-      libusb-1.0-0\
-      make\
-      python
-
-RUN alias python='/usr/bin/python3'
-
-RUN mkdir /app
-RUN mkdir -p /app/libs/celo
-RUN mkdir /app/scripts
-
-WORKDIR /app
-
-COPY ./libs/celo/. ./libs/celo/.
-COPY ./scripts/. ./scripts/.
-
-# Postinstall fails but we don't care
-RUN yarn --cwd ./libs/celo || true
-RUN bash ./scripts/build.celo.sh
+ARG MONORERPO_BUILD_VERSION=latest
+FROM celo-monorepo-build-base:$MONORERPO_BUILD_VERSION
 
 COPY ./package.json .
 COPY ./yarn.lock .

--- a/Dockerfile.monorepo
+++ b/Dockerfile.monorepo
@@ -1,0 +1,27 @@
+FROM node:10
+
+RUN apt update -y && apt install -y \
+      bash\
+      g++\
+      gcc\
+      git\
+      libsecret-1-dev\
+      libusb-1.0-0\
+      make\
+      python
+
+RUN alias python='/usr/bin/python3'
+
+RUN mkdir /app
+RUN mkdir -p /app/libs/celo
+RUN mkdir /app/scripts
+
+WORKDIR /app
+
+COPY ./libs/celo/. ./libs/celo/.
+COPY ./scripts/. ./scripts/.
+
+# Postinstall fails but we don't care
+RUN yarn --cwd ./libs/celo || true
+RUN bash ./scripts/build.celo.sh
+


### PR DESCRIPTION
Still hitting the disk space issue so I'm trying a slightly different approach on builds:
- First create an image that has the celo-monorepo build and is tagged by the celo-monorerpo commit hash
- Then use that as a base for the final build.
