### PR TITLE
Leave default logger in prod even if it's not json log-line

### DIFF
--- a/apps/onboarding/src/main.ts
+++ b/apps/onboarding/src/main.ts
@@ -6,9 +6,7 @@ import { AppModule } from './app.module'
 import { appConfig } from './config/app.config'
 
 async function bootstrap() {
-  const app = await NestFactory.create<NestApplication>(AppModule, {
-    logger: process.env.NODE_ENV === "production" ? false : undefined
-  })
+  const app = await NestFactory.create<NestApplication>(AppModule)
   const logger = app.get(Logger)
   app.useLogger(logger)
   const cfg = app.get(ConfigService).get<ConfigType<typeof appConfig>>('app')

--- a/apps/relayer/src/main.ts
+++ b/apps/relayer/src/main.ts
@@ -7,10 +7,7 @@ import { AppModule } from './app.module'
 import { AppConfig } from './config/app.config'
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule, {
-    logger: process.env.NODE_ENV === "production" ? false : undefined
-  })
-
+  const app = await NestFactory.create(AppModule)
   const appConfig = app.get(ConfigService).get<AppConfig>('app')
   app.connectMicroservice<TcpOptions>({
     transport: Transport.TCP,


### PR DESCRIPTION
That code was problematic because it caused errors that happen during the platform init phase to not show up. They still won't be json formatted but they will show up.