### PR TITLE
Refactor transaction validation to support batched transactions

### DIFF
--- a/apps/onboarding/src/app.controller.spec.ts
+++ b/apps/onboarding/src/app.controller.spec.ts
@@ -3,6 +3,7 @@ import { appConfig } from '@app/onboarding/config/app.config'
 import { quotaConfig } from '@app/onboarding/config/quota.config'
 import { Session } from '@app/onboarding/session/session.entity'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
+import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { networkConfig } from '@app/utils/config/network.config'
 import { ContractKit } from '@celo/contractkit'
@@ -47,6 +48,7 @@ describe('AppController', () => {
         WalletService,
         SubsidyService,
         ContractKit,
+        TxParserService,
         KomenciLoggerService,
         {
           provide: appConfig.KEY,

--- a/apps/onboarding/src/app.module.ts
+++ b/apps/onboarding/src/app.module.ts
@@ -3,6 +3,7 @@ import { NodeProviderType } from '@app/blockchain/config/node.config'
 import { EventType, KomenciLoggerModule, KomenciLoggerService } from '@app/komenci-logger'
 import { ApiErrorFilter } from '@app/komenci-logger/filters/api-error.filter'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
+import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
 import { HttpModule, Logger, Module, Scope } from '@nestjs/common'
@@ -106,6 +107,7 @@ import { SessionModule } from './session/session.module'
   providers: [
     SubsidyService,
     WalletService,
+    TxParserService,
     SessionService,
     RelayerProxyService,
     {

--- a/apps/onboarding/src/subsidy/subsidy.service.spec.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.spec.ts
@@ -1,6 +1,7 @@
 import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
 import { RequestAttestationsDto } from '@app/onboarding/dto/RequestAttestationsDto'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
+import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { ContractKit } from '@celo/contractkit'
 import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
@@ -37,6 +38,7 @@ describe('SubsidyService', () => {
         SubsidyService,
         ContractKit,
         WalletService,
+        TxParserService,
         {
           provide: appConfig.KEY,
           useValue: cfg

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -1,8 +1,9 @@
 import { AppConfig, appConfig } from '@app/onboarding/config/app.config'
 import { RequestAttestationsDto } from '@app/onboarding/dto/RequestAttestationsDto'
-import { InvalidWallet, MetaTxValidationError } from '@app/onboarding/wallet/errors'
+import { InvalidWallet, TxParseErrors } from '@app/onboarding/wallet/errors'
+import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
-import { Err, Ok, Result } from '@celo/base/lib/result'
+import { Ok, Result } from '@celo/base/lib/result'
 import { ContractKit } from '@celo/contractkit'
 import { RawTransaction, toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { Inject, Injectable } from '@nestjs/common'
@@ -13,6 +14,7 @@ import { Session } from '../session/session.entity'
 export class SubsidyService {
   constructor(
     private readonly walletService: WalletService,
+    private readonly txParserService: TxParserService,
     private readonly contractKit: ContractKit,
     @Inject(appConfig.KEY)
     private readonly cfg: AppConfig
@@ -21,7 +23,7 @@ export class SubsidyService {
   public async isValid(
     input: RequestAttestationsDto,
     session: Session
-  ): Promise<Result<boolean, InvalidWallet | MetaTxValidationError>> {
+  ): Promise<Result<boolean, InvalidWallet | TxParseErrors>> {
     const walletValid = await this.walletService.isValidWallet(
       input.walletAddress,
       session.externalAccount
@@ -32,26 +34,17 @@ export class SubsidyService {
     }
 
     const attestations = await this.contractKit.contracts.getAttestations()
-    const txMetadata = await this.walletService.extractMetaTxData(
-      input.requestTx
-    )
-    if (txMetadata.ok === false) {
-      return txMetadata
-    }
-    const requestValid = await this.walletService.isAllowedMetaTransaction(
-      txMetadata.result,
-      [
-        {
-          destination: attestations.address,
-          methodId: attestations.methodIds.request
+    const res = await this.txParserService.parse(
+      input.requestTx,
+      input.walletAddress, {
+        [attestations.address]: {
+          [attestations.methodIds.request]: true
         }
-      ]
-    )
+    })
 
-    if (requestValid.ok === false) {
-      return requestValid
+    if (res.ok === false) {
+      return res
     }
-
     return Ok(true)
   }
 

--- a/apps/onboarding/src/utils/testing/mock-web3-provider.ts
+++ b/apps/onboarding/src/utils/testing/mock-web3-provider.ts
@@ -2,7 +2,10 @@ import Web3 from 'web3'
 import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
 
 export type ResultForPayload = (payload: JsonRpcPayload) => [Error | null, JsonRpcResponse?]
-export const buildMockWeb3Provider = (resultForPayload: ResultForPayload) => {
+export const buildMockWeb3Provider = (
+  resultForPayload: ResultForPayload,
+  overrides: any = {}
+) => {
   const sendMock = jest.fn().mockImplementation((
     payload: JsonRpcPayload,
     callback: (error: Error | null, result?: JsonRpcResponse) => void
@@ -18,13 +21,13 @@ export const buildMockWeb3Provider = (resultForPayload: ResultForPayload) => {
     })
   })
 
-  return jest.fn((_host, _options) => ({
-    host: _host,
+  return {
+    host: 'mock-web3-host',
     connected: true,
     send: sendMock,
     supportsSubscriptions: () => true,
     disconnect: () => true,
-  }))
-
+    ...overrides
+  }
 }
 

--- a/apps/onboarding/src/wallet/decode-txs.ts
+++ b/apps/onboarding/src/wallet/decode-txs.ts
@@ -1,0 +1,91 @@
+import { TransactionDecodeError } from '@app/onboarding/wallet/errors'
+import { Err, Ok, Result } from '@celo/base'
+import { ABI as MetaTxWalletABI } from '@celo/contractkit/lib/generated/MetaTransactionWallet'
+import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+
+const InputDataDecoder = require('ethereum-input-data-decoder')
+const MetaTxWalletDecoder = new InputDataDecoder(MetaTxWalletABI)
+
+const EXECUTE_TRANSACTIONS_INPUTS = 4
+const EXECUTE_META_TRANSACTION_INPUTS = 6
+
+export const decodeExecuteMetaTransaction = (
+  tx: RawTransaction
+): Result<RawTransaction, TransactionDecodeError> => {
+  const result = decode<[string, any, Buffer]>(
+    tx,
+    'executeMetaTransaction',
+    EXECUTE_META_TRANSACTION_INPUTS
+  )
+
+  if (result.ok === false) {
+    return result
+  }
+  const inputs = result.result
+
+  return Ok({
+    destination: inputs[0],
+    value: inputs[1].toString(),
+    data: inputs[2].toString('hex')
+  })
+}
+
+export const decodeExecuteTransactions = (
+  tx: RawTransaction
+): Result<RawTransaction[], TransactionDecodeError> => {
+  const result = decode<[string[], any[], Buffer, number[]]>(
+    tx,
+    'executeTransactions',
+    EXECUTE_TRANSACTIONS_INPUTS
+  )
+
+  if (result.ok === false) {
+    return result
+  }
+
+  const inputs = result.result
+  let offset = 0
+
+  return Ok(inputs[3].map((dataLength, idx) => {
+    let data: string
+    if (dataLength === 0) {
+      data = ""
+    } else {
+      data = inputs[2].slice(offset, offset+dataLength).toString('hex')
+      offset += dataLength
+    }
+    return  {
+      destination: inputs[0][idx],
+      value: inputs[1][idx].toString(),
+      data
+    }
+  }))
+}
+const decode = <TxInput extends any[]>(
+  tx: RawTransaction,
+  method: string,
+  expectedInputsLength: number
+): Result<TxInput, TransactionDecodeError> => {
+  let decodedData: any
+  try {
+    decodedData = MetaTxWalletDecoder.decodeData(tx.data)
+  } catch (e) {
+    return Err(new TransactionDecodeError(tx, e))
+  }
+
+  if (decodedData.method === null) {
+    return Err(new TransactionDecodeError(tx, new Error("Could not find method")))
+  }
+
+  if (decodedData.method !== method) {
+    return Err(new TransactionDecodeError(tx, new Error("Method does not match")))
+  }
+
+  if (decodedData.inputs.length !== expectedInputsLength) {
+    return Err(new TransactionDecodeError(tx, new Error('Invalid inputs length')))
+  }
+
+  return Ok(decodedData.inputs)
+}
+
+

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -1,5 +1,6 @@
 import { ApiError } from '@app/komenci-logger/errors'
 import { RootError } from '@celo/base/lib/result'
+import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { WalletValidationError } from '@celo/komencikit/lib/errors'
 
 export enum WalletErrorType {
@@ -36,54 +37,42 @@ export class InvalidWallet extends ApiError<WalletErrorType> {
 
 export type WalletError = WalletNotDeployed | InvalidImplementation | InvalidWallet
 
-export enum MetaTxValidationErrorTypes {
-  InvalidRootMethod = "InvalidRootMethod",
-  InvalidChildMethod = "InvalidChildMethod",
-  InvalidDestination = "InvalidDestination",
-  InputDecodeError = "InputDecodeError"
+export enum TxParseErrorTypes {
+  InvalidRootTransaction = "MetaTx.InvalidRootTransaction",
+  TransactionNotAllowed = "MetaTx.TransactionNotAllowed",
+  TransactionDecodeError = "MetaTx.TransactionDecodeError"
 }
 
-export class InvalidRootMethod extends ApiError<MetaTxValidationErrorTypes> {
+export class InvalidRootTransaction extends ApiError<TxParseErrorTypes> {
   statusCode = 400
-  metadataProps = ['method']
+  metadataProps = ['tx']
 
-  constructor(readonly method: string) {
-    super(MetaTxValidationErrorTypes.InvalidRootMethod)
+  constructor(readonly tx: RawTransaction) {
+    super(TxParseErrorTypes.InvalidRootTransaction)
   }
 }
 
-export class InvalidChildMethod extends ApiError<MetaTxValidationErrorTypes> {
+export class TransactionNotAllowed extends ApiError<TxParseErrorTypes> {
   statusCode = 400
-  metadataProps = ['method']
+  metadataProps = ['tx']
 
-  constructor(readonly method: string) {
-    super(MetaTxValidationErrorTypes.InvalidChildMethod)
+  constructor(readonly tx: RawTransaction) {
+    super(TxParseErrorTypes.TransactionNotAllowed)
   }
 }
 
-export class InvalidDestination extends ApiError<MetaTxValidationErrorTypes> {
+export class TransactionDecodeError extends ApiError<TxParseErrorTypes> {
   statusCode = 400
-  metadataProps = ['destination']
+  metadataProps = ['tx']
 
-  constructor(readonly destination: string) {
-    super(MetaTxValidationErrorTypes.InvalidDestination)
+  constructor(readonly tx: RawTransaction, readonly error: Error) {
+    super(TxParseErrorTypes.TransactionDecodeError)
+    this.message = error.message
   }
 }
 
-export class InputDecodeError extends ApiError<MetaTxValidationErrorTypes> {
-  statusCode = 400
-  metadataProps = []
-
-  constructor(readonly error?: Error) {
-    super(MetaTxValidationErrorTypes.InputDecodeError)
-    this.message = this.error?.message
-  }
-}
-
-export type MetaTxValidationError =
-  InvalidRootMethod |
-  InvalidChildMethod |
-  InvalidDestination |
-  InputDecodeError
-
+export type TxParseErrors =
+  InvalidRootTransaction |
+  TransactionNotAllowed |
+  TransactionDecodeError
 

--- a/apps/onboarding/src/wallet/tx-parser.service.spec.ts
+++ b/apps/onboarding/src/wallet/tx-parser.service.spec.ts
@@ -1,0 +1,232 @@
+import { BlockchainModule } from '@app/blockchain'
+import { WEB3_PROVIDER } from '@app/blockchain/blockchain.providers'
+import { NodeProviderType } from '@app/blockchain/config/node.config'
+import { normalizeMethodId } from '@app/blockchain/utils'
+import { buildMockWeb3Provider } from '@app/onboarding/utils/testing/mock-web3-provider'
+import { TxParseErrorTypes } from '@app/onboarding/wallet/errors'
+import { AllowedTransactions, TxParserService } from '@app/onboarding/wallet/tx-parser.service'
+import { Address, normalizeAddress, trimLeading0x } from '@celo/base'
+import { CeloTransactionObject, ContractKit } from '@celo/contractkit'
+import { AccountsWrapper } from '@celo/contractkit/lib/wrappers/Accounts'
+import { AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
+import {
+  MetaTransactionWalletWrapper,
+  RawTransaction,
+  toRawTransaction, TransactionInput,
+} from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper'
+import { Test, TestingModule } from '@nestjs/testing'
+import Web3 from 'web3'
+
+describe('TxParserService', () => {
+  let module: TestingModule
+  let service: TxParserService
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        BlockchainModule.forRootAsync({
+          useFactory: () => {
+            return {
+              node: { providerType: NodeProviderType.HTTP, url: "not-a-node" }
+            }
+          }
+        }),
+      ],
+      providers: [ TxParserService ]
+    }).overrideProvider(WEB3_PROVIDER).useValue(
+      buildMockWeb3Provider(() => null)
+    ).compile()
+    service = module.get(TxParserService)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('#onModuleInit', () => {
+    it('should be called on init', async () => {
+      const onModuleInitSpy = jest.spyOn(service, 'onModuleInit')
+      await module.init()
+      expect(onModuleInitSpy).toHaveBeenCalled()
+    })
+
+    it('should set default allowed transactions', async () => {
+      await module.init()
+      expect(service.defaultAllowedTransactions).not.toBeUndefined()
+    })
+
+    it('should set the allowed transactions containing normalized addresses and methodIds', async () => {
+      await module.init()
+      Object.keys(service.defaultAllowedTransactions).forEach(address => {
+        expect(address).toBe(normalizeAddress(address))
+        Object.keys(service.defaultAllowedTransactions[address]).forEach(methodId => {
+          expect(methodId).toBe(normalizeMethodId(methodId))
+        })
+      })
+    })
+  })
+
+  describe.only('#parse', () => {
+    beforeEach(async () => module.init())
+    const addresses: Address[] = [0,0,0,0,0].map(() => Web3.utils.randomHex(20))
+    const metaTxWallet = addresses[0]
+    const otherMetaTxWallet = addresses[1]
+
+    const subjectRaw = async (rawTx: RawTransaction, allowOverride?: AllowedTransactions) => {
+      return service.parse(
+        rawTx,
+        metaTxWallet,
+        allowOverride
+      )
+    }
+
+    const subject = async (tx: CeloTransactionObject<any>, allowOverride?: AllowedTransactions) => {
+      return subjectRaw(toRawTransaction(tx.txo), allowOverride)
+    }
+
+    const normalizedTx = (tx: TransactionInput<any>): RawTransaction => {
+      const rawTx = toRawTransaction(tx)
+      return {
+        destination: normalizeAddress(rawTx.destination),
+        data: trimLeading0x(rawTx.data),
+        value: rawTx.value
+      }
+    }
+
+    const mockSig = {v: 0, r:"0x0", s:"0x0"}
+    let wallet: MetaTransactionWalletWrapper
+    let otherWallet: MetaTransactionWalletWrapper
+    let attestations: AttestationsWrapper
+    let accounts: AccountsWrapper
+    let cUSD: StableTokenWrapper
+
+    beforeEach(async () => {
+      const contractkit = module.get(ContractKit)
+      wallet = await contractkit.contracts.getMetaTransactionWallet(metaTxWallet)
+      otherWallet = await contractkit.contracts.getMetaTransactionWallet(otherMetaTxWallet)
+      attestations = await contractkit.contracts.getAttestations()
+      accounts = await contractkit.contracts.getAccounts()
+      cUSD = await contractkit.contracts.getStableToken()
+    })
+
+    describe('with an invalid root transaction', () => {
+      it('returns an InvalidRootTransaction error', async () => {
+        const res = await subject(cUSD.transfer(addresses[2], "1000"))
+        expect(res.ok).toBe(false)
+        if (res.ok === false) {
+          expect(res.error.errorType).toBe(TxParseErrorTypes.InvalidRootTransaction)
+        }
+      })
+    })
+
+    describe('with an invalid child transaction', () => {
+      it('returns an TransactionNotAllowed error', async () => {
+        const childTx = accounts.createAccount().txo
+        const res = await subject(await wallet.executeMetaTransaction(childTx, mockSig))
+        expect(res.ok).toBe(false)
+
+        if (res.ok === false) {
+          expect(res.error.errorType).toBe(TxParseErrorTypes.TransactionNotAllowed)
+          if (res.error.errorType === TxParseErrorTypes.TransactionNotAllowed) {
+            expect(res.error.tx).toMatchObject(normalizedTx(childTx))
+          }
+        }
+      })
+    })
+
+    describe('with a valid transaction', () => {
+      it('returns an TransactionNotAllowed error', async () => {
+        const childTx = cUSD.approve(addresses[2], "1000").txo
+
+        const res = await subject(await wallet.executeMetaTransaction(childTx, mockSig))
+        expect(res.ok).toBe(true)
+
+        if (res.ok === true) {
+          const txs = res.result
+          expect(txs[0]).toMatchObject(normalizedTx(childTx))
+        }
+      })
+    })
+
+    describe('with a batched transaction', () => {
+      describe('containing an invalid transaction', () => {
+        it('returns an TransactionNotAllowed error', async () => {
+          const childTx1 = cUSD.approve(addresses[2], "1000").txo
+          const childTx2 = accounts.createAccount().txo
+          const batchTx = wallet.executeTransactions([childTx1, childTx2]).txo
+
+          const res = await subject(await wallet.executeMetaTransaction(batchTx, mockSig))
+          expect(res.ok).toBe(false)
+
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(TxParseErrorTypes.TransactionNotAllowed)
+            if (res.error.errorType === TxParseErrorTypes.TransactionNotAllowed) {
+              expect(res.error.tx).toMatchObject(normalizedTx(childTx2))
+            }
+          }
+        })
+      })
+
+      describe('with only valid transactions', () => {
+        it('returns an TransactionNotAllowed error', async () => {
+          const childTx1 = cUSD.approve(addresses[2], "1000").txo
+          const childTx2 = cUSD.approve(addresses[3], "1000").txo
+          const batchTx = wallet.executeTransactions([childTx1, childTx2]).txo
+
+          const res = await subject(await wallet.executeMetaTransaction(batchTx, mockSig))
+          expect(res.ok).toBe(true)
+
+          if (res.ok === true) {
+            const txs = res.result
+            expect(txs[0]).toMatchObject(normalizedTx(childTx1))
+            expect(txs[1]).toMatchObject(normalizedTx(childTx2))
+          }
+        })
+      })
+    })
+
+    describe('with manually specified allowance', () => {
+      describe('with an invalid transaction which is valid in defaults', () => {
+        it('returns an TransactionNotAllowed error', async () => {
+          const childTx = cUSD.approve(addresses[2], "1000").txo
+
+          const res = await subject(await wallet.executeMetaTransaction(childTx, mockSig), {
+            [cUSD.address]: {
+              [cUSD.methodIds.transfer]: true
+            }
+          })
+
+          expect(res.ok).toBe(false)
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(TxParseErrorTypes.TransactionNotAllowed)
+            if (res.error.errorType === TxParseErrorTypes.TransactionNotAllowed) {
+              expect(res.error.tx).toMatchObject(normalizedTx(childTx))
+            }
+          }
+        })
+      })
+
+      describe('with an invalid transaction which is valid in defaults', () => {
+        it('returns an TransactionNotAllowed error', async () => {
+          const childTx = cUSD.approve(addresses[2], "1000").txo
+          const batchTx = wallet.executeTransactions([childTx]).txo
+
+          const res = await subject(await wallet.executeMetaTransaction(batchTx, mockSig), {
+            [cUSD.address]: {
+              [cUSD.methodIds.transfer]: true
+            }
+          })
+
+          expect(res.ok).toBe(false)
+          if (res.ok === false) {
+            expect(res.error.errorType).toBe(TxParseErrorTypes.TransactionNotAllowed)
+            if (res.error.errorType === TxParseErrorTypes.TransactionNotAllowed) {
+              expect(res.error.tx).toMatchObject(normalizedTx(childTx))
+            }
+          }
+        })
+      })
+    })
+  })
+})

--- a/apps/onboarding/src/wallet/tx-parser.service.spec.ts
+++ b/apps/onboarding/src/wallet/tx-parser.service.spec.ts
@@ -136,7 +136,7 @@ describe('TxParserService', () => {
     })
 
     describe('with a valid transaction', () => {
-      it('returns an TransactionNotAllowed error', async () => {
+      it('returns the child transaction', async () => {
         const childTx = cUSD.approve(addresses[2], "1000").txo
 
         const res = await subject(await wallet.executeMetaTransaction(childTx, mockSig))

--- a/apps/onboarding/src/wallet/tx-parser.service.ts
+++ b/apps/onboarding/src/wallet/tx-parser.service.ts
@@ -1,0 +1,196 @@
+import { extractMethodId, normalizeMethodId } from '@app/blockchain/utils'
+import {
+  InvalidRootTransaction, TransactionDecodeError, TransactionNotAllowed,
+  TxParseErrors,
+} from '@app/onboarding/wallet/errors'
+import { Address, Err, normalizeAddress, Ok, Result } from '@celo/base'
+import { ContractKit } from '@celo/contractkit'
+import { ABI as MetaTxWalletABI } from '@celo/contractkit/lib/generated/MetaTransactionWallet'
+import { BaseWrapper } from '@celo/contractkit/lib/wrappers/BaseWrapper'
+import { MetaTransactionWalletWrapper, RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { Injectable, OnModuleInit } from '@nestjs/common'
+
+export type AllowedTransactions = Record<Address, Record<string, boolean>>
+
+const InputDataDecoder = require('ethereum-input-data-decoder')
+const MetaTxWalletDecoder = new InputDataDecoder(MetaTxWalletABI)
+
+@Injectable()
+export class TxParserService implements OnModuleInit {
+  defaultAllowedTransactions: AllowedTransactions
+  constructor(
+    private readonly contractKit: ContractKit
+  ) {}
+
+  async onModuleInit() {
+    const attestations = await this.contractKit.contracts.getAttestations()
+    const accounts = await this.contractKit.contracts.getAccounts()
+    const cUSD = await this.contractKit.contracts.getStableToken()
+    const escrow = await this.contractKit.contracts.getEscrow()
+
+    this.defaultAllowedTransactions = normalizeAllowed({
+      [attestations.address]: {
+        [attestations.methodIds.selectIssuers]: true,
+        [attestations.methodIds.complete]: true,
+      },
+      [accounts.address]: {
+        [accounts.methodIds.setAccount]: true
+      },
+      [cUSD.address]: {
+        [cUSD.methodIds.approve]: true,
+        [cUSD.methodIds.transfer]: true,
+      },
+      [escrow.address]: {
+        [escrow.methodIds.withdraw]: true
+      }
+    })
+  }
+
+  async parse(
+    tx: RawTransaction,
+    metaTxWalletAddress: string,
+    allowedTransactions?: AllowedTransactions
+  ): Promise<Result<RawTransaction[], TxParseErrors>> {
+    const wallet = await this.contractKit.contracts.getMetaTransactionWallet(metaTxWalletAddress)
+    if (!isCallTo(tx, wallet, 'executeMetaTransaction')) {
+      return Err(new InvalidRootTransaction(tx))
+    }
+    const childrenResp = this.getChildren(tx, wallet)
+    if (childrenResp.ok === false) {
+      return childrenResp
+    }
+
+    allowedTransactions = allowedTransactions === undefined
+      ? this.defaultAllowedTransactions
+      : normalizeAllowed(allowedTransactions)
+
+    for (const child of childrenResp.result) {
+      const normDest = normalizeAddress(child.destination)
+      const methodId = extractMethodId(child.data)
+
+      if (!(
+        allowedTransactions[normDest] &&
+        allowedTransactions[normDest][methodId] === true
+      )) {
+        return Err(new TransactionNotAllowed(child))
+      }
+    }
+
+    return Ok(childrenResp.result)
+  }
+
+  private getChildren(
+    tx: RawTransaction,
+    wallet: MetaTransactionWalletWrapper
+  ): Result<RawTransaction[], TransactionDecodeError> {
+    const childResp = this.decodeExecuteMetaTransaction(tx)
+    if (childResp.ok === false) {
+      return childResp
+    }
+    const child = childResp.result
+
+    if (isCallTo(child, wallet, 'executeTransactions')) {
+      return this.decodeExecuteTransactions(child)
+    } else {
+      return Ok([child])
+    }
+  }
+
+  private decodeExecuteMetaTransaction(tx: RawTransaction): Result<RawTransaction, TransactionDecodeError> {
+    const result = this.decode<[string, any, Buffer]>(
+      tx,
+      'executeMetaTransaction',
+      6
+    )
+
+    if (result.ok === false) {
+      return result
+    }
+    const inputs = result.result
+
+    return Ok({
+      destination: inputs[0],
+      value: inputs[1].toString(),
+      data: inputs[2].toString('hex')
+    })
+  }
+
+  private decodeExecuteTransactions(tx: RawTransaction): Result<RawTransaction[], TransactionDecodeError> {
+    const result = this.decode<[string[], any[], Buffer, number[]]>(
+      tx,
+      'executeTransactions',
+      4
+    )
+
+    if (result.ok === false) {
+      return result
+    }
+
+    const inputs = result.result
+    let offset = 0
+    return Ok(inputs[3].map((dataLength, idx) => {
+      let data: string
+      if (dataLength === 0) {
+        data = ""
+      } else {
+        data = inputs[2].slice(offset, offset+dataLength).toString('hex')
+        offset += dataLength
+      }
+      return  {
+        destination: inputs[0][idx],
+        value: inputs[1][idx].toString(),
+        data
+      }
+    }))
+  }
+
+  private decode<TxInput extends any[]>(
+    tx: RawTransaction,
+    method: string,
+    expectedInputsLength: number
+  ): Result<TxInput, TransactionDecodeError> {
+    let decodedData: any
+    try {
+      decodedData = MetaTxWalletDecoder.decodeData(tx.data)
+    } catch (e) {
+      return Err(new TransactionDecodeError(tx, e))
+    }
+
+    if (decodedData.method === null) {
+      return Err(new TransactionDecodeError(tx, new Error("Could not find method")))
+    }
+
+    if (decodedData.method !== method) {
+      return Err(new TransactionDecodeError(tx, new Error("Method does not match")))
+    }
+
+    if (decodedData.inputs.length !== expectedInputsLength) {
+      return Err(new TransactionDecodeError(tx, new Error('Invalid inputs length')))
+    }
+
+    return Ok(decodedData.inputs)
+  }
+
+}
+
+const normalizeAllowed = (allowedMap: AllowedTransactions): AllowedTransactions => {
+  return Object.keys(allowedMap).reduce((addressAcc, address) => {
+    addressAcc[normalizeAddress(address)] = Object.keys(
+      allowedMap[address]
+    ).reduce((methodAcc, methodId) => {
+      methodAcc[normalizeMethodId(methodId)] = allowedMap[address][methodId]
+      return methodAcc
+    }, {})
+    return addressAcc
+  }, {})
+}
+
+const isCallTo = <TContract extends BaseWrapper<any>>(
+  tx: RawTransaction,
+  contract: TContract,
+  method: keyof TContract["methodIds"]
+): boolean => {
+  return normalizeAddress(tx.destination) === normalizeAddress(contract.address) &&
+    extractMethodId(tx.data) === normalizeMethodId(contract.methodIds[method])
+}
+

--- a/apps/onboarding/src/wallet/wallet.service.spec.ts
+++ b/apps/onboarding/src/wallet/wallet.service.spec.ts
@@ -1,18 +1,16 @@
 import { BlockchainModule, ContractsModule } from '@app/blockchain'
+import { WEB3_PROVIDER } from '@app/blockchain/blockchain.providers'
 import { NodeProviderType } from '@app/blockchain/config/node.config'
-import { normalizeMethodId } from '@app/blockchain/utils'
 import { KomenciLoggerModule } from '@app/komenci-logger'
 import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
 import { RelayerProxyService } from '@app/onboarding/relayer/relayer_proxy.service'
 import { Session } from '@app/onboarding/session/session.entity'
 import { SessionService } from '@app/onboarding/session/session.service'
 import { buildMockWeb3Provider } from '@app/onboarding/utils/testing/mock-web3-provider'
-import { MetaTxValidationErrorTypes, WalletErrorType } from '@app/onboarding/wallet/errors'
+import { WalletErrorType } from '@app/onboarding/wallet/errors'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
-import { normalizeAddress, Ok } from '@celo/base'
-import { ContractKit } from '@celo/contractkit'
-import { toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { Ok } from '@celo/base'
 import { MetaTransactionWalletDeployerWrapper } from '@celo/contractkit/lib/wrappers/MetaTransactionWalletDeployer'
 import { Test, TestingModule } from '@nestjs/testing'
 import Web3 from 'web3'
@@ -20,7 +18,6 @@ import Web3 from 'web3'
 jest.mock('@app/komenci-logger/komenci-logger.service')
 jest.mock('@app/onboarding/relayer/relayer_proxy.service')
 jest.mock('@app/onboarding/session/session.service')
-Web3.providers.HttpProvider = buildMockWeb3Provider(() => null)
 
 describe("WalletService", () => {
   const buildModule = async (appCfg: Partial<AppConfig>, networkCfg: Partial<NetworkConfig>) => {
@@ -58,190 +55,10 @@ describe("WalletService", () => {
           useValue: networkCfg
         },
       ]
-    }).compile()
+    }).overrideProvider(WEB3_PROVIDER).useValue(
+      buildMockWeb3Provider(() => null)
+    ).compile()
   }
-
-  describe('#extractMetaTxData', () => {
-    describe('with a random transaction', () => {
-      it('returns a DecodeError', async () => {
-        const module = await buildModule({}, {})
-        const walletService = await module.resolve(WalletService)
-        const contractKit = module.get(ContractKit)
-
-        const attestations = await contractKit.contracts.getAttestations()
-        const testTx = toRawTransaction(
-            (await attestations.request("0x0", 3)).txo
-        )
-        const res = await walletService.extractMetaTxData(testTx)
-
-        expect(res.ok).toBe(false)
-        if (res.ok === false) {
-          expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InputDecodeError)
-        }
-      })
-
-      it('returns an InvalidRootMethod', async () => {
-        const module = await buildModule({}, {})
-        const walletService = await module.resolve(WalletService)
-        const contractKit = module.get(ContractKit)
-
-        const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
-        const testTx = toRawTransaction(wallet.setSigner(Web3.utils.randomHex(20)).txo)
-
-        const res = await walletService.extractMetaTxData(testTx)
-
-        expect(res.ok).toBe(false)
-        if (res.ok === false) {
-          expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidRootMethod)
-        }
-      })
-    })
-
-    describe('with a meta transaction', () => {
-      describe('which is correct', () => {
-        it('returns the methodId and destination!', async () => {
-          const module = await buildModule({}, {})
-          const walletService = await module.resolve(WalletService)
-          const contractKit = module.get(ContractKit)
-
-          const attestations = await contractKit.contracts.getAttestations()
-          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
-          const testTx = toRawTransaction(
-            wallet.executeMetaTransaction(
-              attestations.selectIssuers("0x0").txo,
-              {v: 0, r: "0x0", s: "0x0"}
-            ).txo
-          )
-          const res = await walletService.extractMetaTxData(testTx)
-
-          expect(res.ok).toBe(true)
-          if (res.ok === true) {
-            expect(res.result).toStrictEqual({
-              methodId: normalizeMethodId(attestations.methodIds.selectIssuers),
-              destination: normalizeAddress(attestations.address)
-            })
-          }
-        })
-      })
-    })
-  })
-
-
-  describe('#isAllowedMetaTransaction', () => {
-    describe('with a meta transaction', () => {
-      describe('pointing to an invalid destination', () => {
-        it('returns an InvalidDestination error', async () => {
-          const module = await buildModule({}, {})
-          const walletService = await module.resolve(WalletService)
-          const contractKit = module.get(ContractKit)
-
-          const attestations = await contractKit.contracts.getAttestations()
-          const stableToken = await contractKit.contracts.getStableToken()
-          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
-          const testTx = toRawTransaction(
-            wallet.executeMetaTransaction(
-              stableToken.transfer(Web3.utils.randomHex(20), "10000").txo,
-              {v: 0, r: "0x0", s: "0x0"}
-            ).txo
-          )
-
-          const txMetadata = await walletService.extractMetaTxData(testTx)
-          expect(txMetadata.ok).toBe(true)
-
-          if (txMetadata.ok === true) {
-            const res = await walletService.isAllowedMetaTransaction(
-                txMetadata.result,
-                [
-                  {
-                    destination: attestations.address,
-                    methodId: attestations.methodIds.request
-                  }
-                ]
-            )
-
-            expect(res.ok).toBe(false)
-            if (res.ok === false) {
-              expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidDestination)
-            }
-          }
-        })
-      })
-
-      describe('pointing to an invalid method', () => {
-        it('returns an InvalidChildMethod error', async () => {
-          const module = await buildModule({}, {})
-          const walletService = await module.resolve(WalletService)
-          const contractKit = module.get(ContractKit)
-
-          const attestations = await contractKit.contracts.getAttestations()
-          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
-          const testTx = toRawTransaction(
-              wallet.executeMetaTransaction(
-                  attestations.selectIssuers("0x0").txo,
-                  {v: 0, r: "0x0", s: "0x0"}
-              ).txo
-          )
-
-          const txMetadata = await walletService.extractMetaTxData(testTx)
-          expect(txMetadata.ok).toBe(true)
-
-          if (txMetadata.ok === true) {
-            const res = await walletService.isAllowedMetaTransaction(
-                txMetadata.result,
-              [
-                  {
-                    destination: attestations.address,
-                    methodId: attestations.methodIds.request
-                  }
-                ]
-            )
-
-            expect(res.ok).toBe(false)
-            if (res.ok === false) {
-              expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidChildMethod)
-            }
-          }
-          })
-      })
-
-      describe('which is allowed', () => {
-        it('returns ok!', async () => {
-          const module = await buildModule({}, {})
-          const walletService = await module.resolve(WalletService)
-          const contractKit = module.get(ContractKit)
-
-          const attestations = await contractKit.contracts.getAttestations()
-          const wallet = await contractKit.contracts.getMetaTransactionWallet(Web3.utils.randomHex(20))
-          const testTx = toRawTransaction(
-            wallet.executeMetaTransaction(
-              attestations.selectIssuers("0x0").txo,
-              {v: 0, r: "0x0", s: "0x0"}
-            ).txo
-          )
-
-          const txMetadata = await walletService.extractMetaTxData(testTx)
-          expect(txMetadata.ok).toBe(true)
-
-          if (txMetadata.ok === true) {
-            const res = await walletService.isAllowedMetaTransaction(
-                txMetadata.result,
-                [
-                  {
-                    destination: attestations.address,
-                    methodId: attestations.methodIds.request
-                  }
-                ]
-            )
-
-            expect(res.ok).toBe(false)
-            if (res.ok === false) {
-              expect(res.error.errorType).toBe(MetaTxValidationErrorTypes.InvalidChildMethod)
-            }
-          }
-        })
-      })
-    })
-  })
 
   describe('#deployWallet', () => {
     const validImplementation = Web3.utils.randomHex(20)

--- a/apps/tools/src/tools.module.ts
+++ b/apps/tools/src/tools.module.ts
@@ -1,6 +1,7 @@
 import { BlockchainModule, ContractsModule } from '@app/blockchain'
 import { NodeProviderType } from '@app/blockchain/config/node.config'
 import { WalletConfig, WalletType } from '@app/blockchain/config/wallet.config'
+import { FundingService } from '@app/blockchain/funding.service'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
 import { Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
@@ -53,6 +54,7 @@ import { FundCommand } from './fund.command'
     }),
   ],
   providers: [
+    FundingService,
     FundCommand,
     DeployerCommand,
   ],

--- a/libs/blockchain/src/blockchain.module.ts
+++ b/libs/blockchain/src/blockchain.module.ts
@@ -36,12 +36,10 @@ export class BlockchainModule {
           inject: options.inject || [],
         },
         BlockchainService,
-        FundingService,
         ...this.providers()
       ],
       exports: [
         BlockchainService,
-        FundingService,
         ...this.providers().map(p => p.provide)
       ]
     }

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -1,4 +1,5 @@
 import { Address, Result } from '@celo/base'
+import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 
 export enum EventType {
   // Onboarding service events:
@@ -43,8 +44,7 @@ export type EventPayload = {
   }
   [EventType.MetaTransactionSubmitted]: SessionTxEvent & {
     destination: Address
-    metaTxMethodID: string
-    metaTxDestination: Address
+    childTxs: RawTransaction[]
   }
   // Relayer service events payloads:
   [EventType.RelayerMTWInit]: {


### PR DESCRIPTION
### Overview

Move logic that parses transactions to the `TxParserService` which will validate the structure of the transactions against a list of allowed calls. The structure of the transactions can be either:

- `mtw.executeMetaTransaction(allowedTransaction)`
- `mtw.executeMetaTransaction(mtw.executeTransactions([allowedTransaction1, allowedTransaction2]))`

I couldn't find a use-case that would require a more convoluted recursive transaction structure but supporting that would add complexity as it would mean we needed to also have a maximum recursive depth for the transactions and it would also open us up to gas cost griefing by allowing something like:
```
mtw.executeMetaTransaction(
  mtw.executeMetaTransaction(
    mtw.executeMetaTransaction(
       ...... allowedTransaction
    )
  )
)
```