### PR TITLE
Compute gasPrice off-band to reduce RPC call duration

### DIFF
--- a/apps/relayer/src/chain/errors.ts
+++ b/apps/relayer/src/chain/errors.ts
@@ -1,9 +1,11 @@
 import { MetadataError } from '@app/komenci-logger/errors'
+import { RootError } from '@celo/base'
 import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 
 export enum ChainErrorTypes {
   TxSubmitError = "TxSubmitError",
-  TxDeadletterError = "TxDeadletterError"
+  TxDeadletterError = "TxDeadletterError",
+  GasPriceFetchError = "GasPriceFetchError"
 }
 
 export class TxSubmitError extends MetadataError<ChainErrorTypes.TxSubmitError> {
@@ -21,5 +23,12 @@ export class TxDeadletterError extends MetadataError<ChainErrorTypes.TxDeadlette
   constructor(readonly err: Error, readonly txHash: string) {
     super(ChainErrorTypes.TxDeadletterError)
     this.message = `TxSubmitError: ${err.message}`
+  }
+}
+
+export class GasPriceFetchError extends RootError<ChainErrorTypes.GasPriceFetchError> {
+  constructor(readonly err: Error) {
+    super(ChainErrorTypes.GasPriceFetchError)
+    this.message = `GasPriceFetchError: ${err.message}`
   }
 }

--- a/apps/relayer/src/chain/transaction.service.spec.ts
+++ b/apps/relayer/src/chain/transaction.service.spec.ts
@@ -34,6 +34,7 @@ describe('TransactionService', () => {
     testWalletConfig: Partial<WalletConfig>
   ): Promise<TestingModule>  => {
     const appConfigValue: Partial<AppConfig> = {
+      gasPriceFallback: "1000000000",
       ...testAppConfig
     }
 

--- a/apps/relayer/src/config/app.config.ts
+++ b/apps/relayer/src/config/app.config.ts
@@ -10,7 +10,8 @@ export const appConfig = registerAs('app', () => {
     transactionMaxGas: parseInt(process.env.TRANSACTION_MAX_GAS, 10) || 1000000,
     gasPriceUpdateIntervalMs: parseInt(process.env.GAS_PRICE_UPDATE_INTERVAL_MS, 10) || 30000, // 30s
     gasPriceMultiplier: parseFloat(process.env.GAS_PRICE_MULTIPLIER) || 5,
-    gasPriceFallback: process.env.GAS_PRICE_FALLBACK || "1000000000" // 1 Gwei
+    gasPriceFallback: process.env.GAS_PRICE_FALLBACK || "500000000", // 0.5 Gwei
+    maxGasPrice: process.env.MAX_GAS_PRICE || "3000000000" // 3 Gwei
   }
 })
 

--- a/apps/relayer/src/config/app.config.ts
+++ b/apps/relayer/src/config/app.config.ts
@@ -7,7 +7,10 @@ export const appConfig = registerAs('app', () => {
     logLevel: process.env.LOG_LEVEL || 'debug',
     transactionCheckIntervalMs: parseInt(process.env.TRANSACTION_CHECK_INTERVAL_MS, 10) || 1000,
     transactionTimeoutMs: parseInt(process.env.TRANSACTION_TIMEOUT_MS, 10) || 20000,
-    transactionMaxGas: parseInt(process.env.TRANSACTION_MAX_GAS, 10) || 1000000
+    transactionMaxGas: parseInt(process.env.TRANSACTION_MAX_GAS, 10) || 1000000,
+    gasPriceUpdateIntervalMs: parseInt(process.env.GAS_PRICE_UPDATE_INTERVAL_MS, 10) || 30000, // 30s
+    gasPriceMultiplier: parseFloat(process.env.GAS_PRICE_MULTIPLIER) || 5,
+    gasPriceFallback: process.env.GAS_PRICE_FALLBACK || "1000000000" // 1 Gwei
   }
 })
 

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -68,6 +68,7 @@ export type EventPayload = {
   },
   [EventType.GasPriceUpdate]: {
     gasPriceGwei: number
+    cappedAtMax: boolean
   }
 }
 

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -16,6 +16,7 @@ export enum EventType {
   TxTimeout = 'TxTimeout',
   RuleVerified = 'RuleVerified',
   RelayerBalance = 'RelayerBalance',
+  GasPriceUpdate = 'GasPriceUpdate',
 }
 
 export type EventPayload = {
@@ -64,6 +65,9 @@ export type EventPayload = {
   [EventType.TxTimeout]: TxEvent & {
     deadLetterHash: string,
     nonce: number
+  },
+  [EventType.GasPriceUpdate]: {
+    gasPriceGwei: number
   }
 }
 


### PR DESCRIPTION
### Overview

Computing gasPrice per transaction requires a view call to the chain and it ends up being pretty slow, after removing the static gasPrice our relayers jumped to around ~3s to submit a transaction from ~300ms.

This PR moves the gasPrice calculation off-band so that we maintain it outside of the RPC calls and thus not incur the performance penalty.