### PR TITLE
Improve debugging experience

### DIFF
--- a/apps/onboarding/src/app.controller.ts
+++ b/apps/onboarding/src/app.controller.ts
@@ -10,6 +10,7 @@ import { QuotaGuard } from '@app/onboarding/session/quota.guard'
 import { Session as SessionEntity } from '@app/onboarding/session/session.entity'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
 import { WalletErrorType } from '@app/onboarding/wallet/errors'
+import { TransactionWithMetadata } from '@app/onboarding/wallet/method-filter'
 import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
@@ -279,7 +280,7 @@ export class AppController {
   private logMetaTransaction(
     relayerResp: RelayerResponse<string>,
     metaTx: RawTransaction,
-    childTxs: RawTransaction[],
+    childTxs: TransactionWithMetadata[],
     session: SessionEntity
   ) {
     this.logger.event(EventType.MetaTransactionSubmitted, {
@@ -292,9 +293,11 @@ export class AppController {
     })
 
     childTxs.map(childTx => ({
-      value: childTx.value,
-      destination: childTx.destination,
-      methodId: extractMethodId(childTx.data)
+      value: childTx.raw.value,
+      destination: childTx.raw.destination,
+      methodId: childTx.methodId,
+      methodName: childTx.methodName,
+      contractName: childTx.contractName
     })).forEach((childTx) => this.logger.event(
       EventType.ChildMetaTransactionSubmitted, {
         sessionId: session.id,

--- a/apps/onboarding/src/gateway/gateway.service.ts
+++ b/apps/onboarding/src/gateway/gateway.service.ts
@@ -30,7 +30,6 @@ export class GatewayService implements OnModuleInit {
       this.moduleRef.create(DeviceAttestationRule),
       this.moduleRef.create(SignatureRule)
     ])
-
   }
 
   async verify(

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -38,7 +38,7 @@ export class SubsidyService {
       input.requestTx,
       input.walletAddress,
       new MethodFilter().addContract(
-        CeloContract.Accounts,
+        CeloContract.Attestations,
         await this.contractKit.contracts.getAttestations(),
         ["request"]
       )

--- a/apps/onboarding/src/wallet/method-filter.ts
+++ b/apps/onboarding/src/wallet/method-filter.ts
@@ -1,0 +1,53 @@
+import { extractMethodId, normalizeMethodId } from '@app/blockchain/utils'
+import { Err, normalizeAddress, Ok, Result } from '@celo/base'
+import { CeloContract } from '@celo/contractkit'
+import { BaseWrapper } from '@celo/contractkit/lib/wrappers/BaseWrapper'
+import { RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { Contract } from 'web3-eth-contract'
+
+export interface TransactionWithMetadata {
+  raw: RawTransaction,
+  methodId: string,
+  methodName: string,
+  contractName: string
+}
+
+export class MethodFilter {
+  private allowed: Map<string, boolean> = new Map()
+  private methodName: Map<string, string> = new Map()
+  private contractName: Map<string, string> = new Map()
+
+  addContract<T extends Contract>(
+    name: CeloContract,
+    wrapper: BaseWrapper<T>,
+    methods: Array<keyof T["methods"]>
+  ): MethodFilter {
+    this.contractName.set(normalizeAddress(wrapper.address), name)
+    methods.forEach(methodName => {
+      const methodId = wrapper.methodIds[methodName]
+      const methodKey = this.buildKey(wrapper.address, methodId)
+      this.allowed.set(methodKey, true)
+      this.methodName.set(methodKey, methodName as string)
+    })
+
+    return this
+  }
+
+  find(raw: RawTransaction): Result<TransactionWithMetadata, any> {
+    const methodId = extractMethodId(raw.data)
+    const key = this.buildKey(raw.destination, methodId)
+    if (this.allowed.get(key) === true) {
+      return Ok({
+        raw: raw,
+        methodId: methodId,
+        methodName: this.methodName.get(key),
+        contractName: this.contractName.get(normalizeAddress(raw.destination))
+      })
+    }
+    return Err(new Error())
+  }
+  private buildKey(contractAddress, methodId: string): string {
+    return `${normalizeAddress(contractAddress)}:${normalizeMethodId(methodId)}`
+  }
+}
+

--- a/apps/relayer/src/chain/transaction.service.spec.ts
+++ b/apps/relayer/src/chain/transaction.service.spec.ts
@@ -235,7 +235,7 @@ describe('TransactionService', () => {
           from: relayerAddress
         }))
 
-        expect(watchTransaction).toHaveBeenCalledWith(tx.hash)
+        expect(watchTransaction).toHaveBeenCalledWith(tx.hash, undefined)
 
         // Ensure the checkTransactions method is called
         jest.runOnlyPendingTimers()
@@ -308,7 +308,7 @@ describe('TransactionService', () => {
           from: relayerAddress
         }))
 
-        expect(watchTransaction).toHaveBeenCalledWith(tx.hash)
+        expect(watchTransaction).toHaveBeenCalledWith(tx.hash, undefined)
         expect(unwatchTransaction).not.toHaveBeenCalled()
 
         jest.runOnlyPendingTimers()

--- a/apps/relayer/src/chain/transaction.service.ts
+++ b/apps/relayer/src/chain/transaction.service.ts
@@ -159,7 +159,7 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
     const gasPrice = parseInt(tx.gasPrice, 10)
 
     this.logger.event(EventType.TxConfirmed, {
-      isRevert: txReceipt.status === false,
+      status: txReceipt.status === false ? "Reverted" : "Ok",
       txHash: tx.hash,
       gasUsed: txReceipt.gasUsed,
       gasPrice: gasPrice,

--- a/apps/relayer/src/chain/transaction.service.ts
+++ b/apps/relayer/src/chain/transaction.service.ts
@@ -174,8 +174,8 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
    * @param tx Expired tx
    */
   private async deadLetter(tx: Transaction) {
+    const ctx = this.transactionCtx.get(tx.hash)
     try {
-      const ctx = this.transactionCtx.get(tx.hash)
       const result = await this.kit.sendTransaction({
         to: this.walletCfg.address,
         from: this.walletCfg.address,
@@ -194,7 +194,7 @@ export class TransactionService implements OnModuleInit, OnModuleDestroy {
       }, ctx)
     } catch (e) {
       const err = new TxDeadletterError(e, tx.hash)
-      this.logger.error(err)
+      this.logger.errorWithContext(err, ctx)
     }
   }
 

--- a/apps/relayer/src/config/app.config.ts
+++ b/apps/relayer/src/config/app.config.ts
@@ -13,7 +13,8 @@ export const appConfig = registerAs('app', () => {
     gasPriceUpdateIntervalMs: parseInt(process.env.GAS_PRICE_UPDATE_INTERVAL_MS, 10) || 30000, // 30s
     gasPriceMultiplier: parseFloat(process.env.GAS_PRICE_MULTIPLIER) || 5,
     gasPriceFallback: process.env.GAS_PRICE_FALLBACK || "500000000", // 0.5 Gwei
-    maxGasPrice: process.env.MAX_GAS_PRICE || "3000000000" // 3 Gwei
+    maxGasPrice: process.env.MAX_GAS_PRICE || "3000000000", // 3 Gwei
+    odisTimeoutMs: parseInt(process.env.ODIS_TIMEOUT_MS, 10) || 4000, // 4s
   }
 })
 

--- a/apps/relayer/src/dto/GetPhoneNumberSignatureDto.ts
+++ b/apps/relayer/src/dto/GetPhoneNumberSignatureDto.ts
@@ -1,0 +1,16 @@
+import { RelayerCommandDto } from 'apps/relayer/src/dto/RelayerCommandDto'
+import {
+  IsBase64,
+  IsOptional,
+  IsString
+} from 'class-validator'
+
+export class GetPhoneNumberSignatureDto extends RelayerCommandDto {
+  @IsString()
+  @IsBase64()
+  blindedPhoneNumber: string
+
+  @IsString()
+  @IsOptional()
+  clientVersion: string
+}

--- a/apps/relayer/src/dto/RelayerCommandDto.ts
+++ b/apps/relayer/src/dto/RelayerCommandDto.ts
@@ -1,0 +1,23 @@
+import { IsArray, IsHexadecimal, IsOptional, IsString, ValidateNested } from 'class-validator'
+
+export class RelayerTraceContext {
+  @IsHexadecimal()
+  traceId: string
+
+  @ValidateNested()
+  labels: TraceContextLabel[]
+}
+
+export class TraceContextLabel {
+  @IsString()
+  key: string
+
+  @IsString()
+  value: string
+}
+
+export class RelayerCommandDto {
+  @ValidateNested()
+  context?: RelayerTraceContext
+}
+

--- a/apps/relayer/src/dto/SignPersonalMessageDto.ts
+++ b/apps/relayer/src/dto/SignPersonalMessageDto.ts
@@ -1,8 +1,9 @@
+import { RelayerCommandDto } from 'apps/relayer/src/dto/RelayerCommandDto'
 import {
   IsNotEmpty,
 } from 'class-validator'
 
-export class SignPersonalMessageDto {
+export class SignPersonalMessageDto extends RelayerCommandDto {
   @IsNotEmpty()
   data: string
 }

--- a/apps/relayer/src/dto/SubmitTransactionBatchDto.ts
+++ b/apps/relayer/src/dto/SubmitTransactionBatchDto.ts
@@ -1,7 +1,8 @@
 import { RawTransactionDto } from 'apps/relayer/src/dto/RawTransactionDto'
+import { RelayerCommandDto } from 'apps/relayer/src/dto/RelayerCommandDto'
 import { ValidateNested } from 'class-validator'
 
-export class SubmitTransactionBatchDto {
+export class SubmitTransactionBatchDto extends RelayerCommandDto {
   @ValidateNested({each: true})
   transactions: RawTransactionDto[]
 }

--- a/apps/relayer/src/dto/SubmitTransactionDto.ts
+++ b/apps/relayer/src/dto/SubmitTransactionDto.ts
@@ -1,7 +1,8 @@
 import { RawTransactionDto } from 'apps/relayer/src/dto/RawTransactionDto'
+import { RelayerCommandDto } from 'apps/relayer/src/dto/RelayerCommandDto'
 import { ValidateNested } from 'class-validator'
 
-export class SubmitTransactionDto {
+export class SubmitTransactionDto extends RelayerCommandDto {
   @ValidateNested()
   transaction: RawTransactionDto
 }

--- a/apps/relayer/src/odis/odis.service.spec.ts
+++ b/apps/relayer/src/odis/odis.service.spec.ts
@@ -1,4 +1,5 @@
 import { walletConfig, WalletConfig } from '@app/blockchain/config/wallet.config'
+import { KomenciLoggerModule } from '@app/komenci-logger'
 import { DistributedBlindedPepperDto } from '@app/onboarding/dto/DistributedBlindedPepperDto'
 import { networkConfig, NetworkConfig } from '@app/utils/config/network.config'
 import { ContractKit, OdisUtils } from '@celo/contractkit'
@@ -39,7 +40,9 @@ describe('OdisService', () => {
     }
 
     const module = await Test.createTestingModule({
-      imports: [],
+      imports: [
+        KomenciLoggerModule.forRoot()
+      ],
       providers: [
         OdisService,
         { provide: ContractKit, useValue: contractKit },

--- a/apps/relayer/src/odis/odis.service.spec.ts
+++ b/apps/relayer/src/odis/odis.service.spec.ts
@@ -76,7 +76,7 @@ describe('OdisService', () => {
       }
       
       const svc = await setupService({}, {}, {})
-      const res = await svc.getPhoneNumberIdentifier(input)
+      const res = await svc.getPhoneNumberSignature(input)
       expect(res.ok).toBe(true)
       if (res.ok) {
         expect(getBlindedPhoneNumberSignature).toHaveBeenCalled()
@@ -98,7 +98,7 @@ describe('OdisService', () => {
         }
 
         const svc = await setupService({}, {}, {})
-        const res = await svc.getPhoneNumberIdentifier(input)
+        const res = await svc.getPhoneNumberSignature(input)
         expect(res.ok).toBe(false)
         if (res.ok === false) {
           expect(res.error.errorType).toBe(OdisQueryErrorTypes.OutOfQuota)
@@ -127,7 +127,7 @@ describe('OdisService', () => {
         }
 
         const svc = await setupService({}, {}, {})
-        const res = await svc.getPhoneNumberIdentifier(input)
+        const res = await svc.getPhoneNumberSignature(input)
         expect(res.ok).toBe(true)
         if (res.ok) {
           expect(getBlindedPhoneNumberSignature).toHaveBeenCalled()
@@ -152,7 +152,7 @@ describe('OdisService', () => {
         }
 
         const svc = await setupService({}, {}, {})
-        const res = await svc.getPhoneNumberIdentifier(input)
+        const res = await svc.getPhoneNumberSignature(input)
         expect(res.ok).toBe(false)
         if (res.ok === false) {
           expect(res.error.errorType).toBe(OdisQueryErrorTypes.Unknown)

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -52,6 +52,8 @@ export type EventPayload = {
     destination: Address
     value: string,
     methodId: string,
+    methodName: string,
+    contractName: string
   }
   // Relayer service events payloads:
   [EventType.RelayerMTWInit]: {

--- a/libs/komenci-logger/src/events.ts
+++ b/libs/komenci-logger/src/events.ts
@@ -61,7 +61,7 @@ export type EventPayload = {
   }
   [EventType.TxSubmitted]: TxEvent
   [EventType.TxConfirmed]: TxEvent & {
-    isRevert: boolean
+    status: string
     gasPrice: number
     gasUsed: number
     gasCost: number

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -53,8 +53,8 @@ export class KomenciLoggerService implements KomenciLogger {
     }
   }
 
-  errorWithContext(error: Error, ctx: EventContext) {
-    const context = this.expandContext(ctx)
+  errorWithContext(error: Error, ctx?: EventContext) {
+    const context = ctx ? this.expandContext(ctx) : {}
     if (isApiError(error) || isMetadataError(error)) {
       this.logger.error(
         {

--- a/libs/komenci-logger/src/komenci-logger.service.ts
+++ b/libs/komenci-logger/src/komenci-logger.service.ts
@@ -40,18 +40,36 @@ export class KomenciLoggerService implements KomenciLogger {
       this.logger.error(
         { error: error.errorType, ...error.getMetadata() },
         error.stack,
-        "KomenciLoggerService",
       )
     } else if (isRootError(error)) {
       this.logger.error(
         { error: error.errorType, },
         error.stack,
-        "KomenciLoggerService",
       )
     } else if (isError(error)) {
       this.logger.error((error as Error).stack, context, ...args)
     } else {
       this.logger.error(trace || error, context, ...args)
+    }
+  }
+
+  errorWithContext(error: Error, ctx: EventContext) {
+    const context = this.expandContext(ctx)
+    if (isApiError(error) || isMetadataError(error)) {
+      this.logger.error(
+        {
+          error: error.errorType,
+          ...error.getMetadata(),
+          ...context
+        },
+      )
+    } else if (isRootError(error)) {
+      this.logger.error(
+        { error: error.errorType, ...context },
+        error.stack,
+      )
+    } else if (isError(error)) {
+      this.logger.error(context, (error as Error).stack)
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "uuid": "^8.3.0",
     "web3": "1.2.4",
     "web3-core": "1.2.4",
-    "web3-core-helpers": "1.2.4"
+    "web3-core-helpers": "1.2.4",
+    "web3-eth-contract": "1.2.4"
   },
   "devDependencies": {
     "@celo/typescript": "^0.0.1",


### PR DESCRIPTION
### Overview

This medium-sized PR combines a few improvements to how we log things, and one drive-by refactoring of how we handle ODIS communication that will both help us debug and give us more options into how we want to treat the issues there.

__The logging improvements__

- Passing a trace context to the relayers which lets us correlate log messages across services - this makes it way, way easier to correlate a reverted transaction with the request where it originates.
- Attach additional metadata to the decoded meta transactions. Right now we're logging the method id and contract address of the meta transactions, but figuring out which contract/method they relate to is non-trivial and network dependent. With this update we will log contract name and method name for all the child meta transactions. This will also be super useful when debugging reverted transactions.

__The ODIS improvement consists__

Refactoring the service to use the `@retry` decorator and implement timeout at the service level. This way we have the option of setting our timeouts in such a way that the Relayer can retry once after hitting a timeout and probably succeed in getting the signature faster, without having to bubble up the error all the way to Valora.

