### PR TITLE
[Hotfix] Force 'from' field to be specified

### DIFF
--- a/apps/relayer/src/odis/odis.service.spec.ts
+++ b/apps/relayer/src/odis/odis.service.spec.ts
@@ -2,7 +2,8 @@ import { walletConfig, WalletConfig } from '@app/blockchain/config/wallet.config
 import { KomenciLoggerModule } from '@app/komenci-logger'
 import { DistributedBlindedPepperDto } from '@app/onboarding/dto/DistributedBlindedPepperDto'
 import { networkConfig, NetworkConfig } from '@app/utils/config/network.config'
-import { ContractKit, OdisUtils } from '@celo/contractkit'
+import { CeloTransactionObject, ContractKit, OdisUtils } from '@celo/contractkit'
+import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
 import { replenishQuota } from '@celo/phone-number-privacy-common/lib/test/utils'
 import { Test } from '@nestjs/testing'
 import { appConfig, AppConfig } from 'apps/relayer/src/config/app.config'
@@ -15,9 +16,24 @@ jest.mock('@celo/phone-number-privacy-common/lib/test/utils', () => {
     replenishQuota: jest.fn()
   }
 })
+jest.mock('@celo/contractkit')
+jest.mock('@celo/contractkit/lib/wrappers/GoldTokenWrapper')
+jest.mock('@celo/contractkit/lib/contract-cache')
 
 describe('OdisService', () => {
-  const contractKit = jest.fn()
+  // @ts-ignore
+  const contractKit = new ContractKit()
+  // @ts-ignore
+  const celoTxObject = {
+    sendAndWaitForReceipt: jest.fn()
+  }
+  // @ts-ignore
+  contractKit.contracts = new WrapperCache()
+  const goldToken = {
+    transfer: ()=>{return celoTxObject}
+  }
+  jest.spyOn(contractKit.contracts, 'getGoldToken').mockResolvedValue(goldToken as any)
+
   const setupService = async (
     testAppConfig: Partial<AppConfig>,
     testWalletConfig: Partial<WalletConfig>,

--- a/apps/relayer/src/odis/odis.service.spec.ts
+++ b/apps/relayer/src/odis/odis.service.spec.ts
@@ -106,7 +106,8 @@ describe('OdisService', () => {
         if (res.ok === false) {
           expect(res.error.errorType).toBe(OdisQueryErrorTypes.OutOfQuota)
         }
-        expect(replenishQuota).toHaveBeenCalled()
+        // Cody TODO: Reinstate once merge with mono is ready
+        // expect(replenishQuota).toHaveBeenCalled()
         expect(getBlindedPhoneNumberSignature).toHaveBeenCalledTimes(2)
       })
 
@@ -136,7 +137,8 @@ describe('OdisService', () => {
           expect(getBlindedPhoneNumberSignature).toHaveBeenCalled()
           expect(res.result).toBe(combinedSignature)
         }
-        expect(replenishQuota).toHaveBeenCalled()
+        // Cody TODO: Reinstate once merge with mono is ready
+        // expect(replenishQuota).toHaveBeenCalled()
         expect(getBlindedPhoneNumberSignature).toHaveBeenCalledTimes(2)
       })
     })

--- a/apps/relayer/src/odis/odis.service.spec.ts
+++ b/apps/relayer/src/odis/odis.service.spec.ts
@@ -30,7 +30,7 @@ describe('OdisService', () => {
   // @ts-ignore
   contractKit.contracts = new WrapperCache()
   const goldToken = {
-    transfer: ()=>{return celoTxObject}
+    transfer: () => celoTxObject
   }
   jest.spyOn(contractKit.contracts, 'getGoldToken').mockResolvedValue(goldToken as any)
 

--- a/apps/relayer/src/odis/odis.service.ts
+++ b/apps/relayer/src/odis/odis.service.ts
@@ -6,7 +6,6 @@ import { Err, Ok, Result, RootError } from '@celo/base/lib/result'
 import { ContractKit, OdisUtils } from '@celo/contractkit'
 import { AuthSigner, ServiceContext } from '@celo/contractkit/lib/identity/odis/query'
 import { retry } from '@celo/komencikit/lib/retry'
-import { replenishQuota } from '@celo/phone-number-privacy-common/lib/test/utils'
 import { Inject, Injectable } from '@nestjs/common'
 import { appConfig, AppConfig } from 'apps/relayer/src/config/app.config'
 import { GetPhoneNumberSignatureDto } from 'apps/relayer/src/dto/GetPhoneNumberSignatureDto'
@@ -86,7 +85,11 @@ export class OdisService {
     if (res.ok === false) {
       this.logger.errorWithContext(res.error, input.context)
       if (res.error.errorType === OdisQueryErrorTypes.OutOfQuota) {
-        await replenishQuota(this.walletCfg.address, this.contractKit)
+        // Cody TODO: Reinstate once merge with mono is ready
+        // await replenishQuota(this.walletCfg.address, this.contractKit)
+        const goldToken = await this.contractKit.contracts.getGoldToken()
+        const selfTransferTx = goldToken.transfer(this.walletCfg.address, 1)
+        await selfTransferTx.sendAndWaitForReceipt({from: this.walletCfg.address})
       }
     }
 


### PR DESCRIPTION
This allows relayer accounts to increase their ODIS quota which is blocked currently due to a bug. This is a temporary fix and will be replaced once we can update the monorepo submodule.