### PR TITLE
Include cUSD approve in the subsidies attestation request transaction

### DIFF
--- a/apps/onboarding/src/dto/RequestAttestationsDto.ts
+++ b/apps/onboarding/src/dto/RequestAttestationsDto.ts
@@ -2,7 +2,7 @@ import { IsCeloAddress } from '@app/onboarding/utils/validators'
 import { RawTransactionDto } from 'apps/relayer/src/dto/RawTransactionDto'
 import {
   IsNotEmpty,
-  IsNumber,
+  IsNumber, IsOptional,
   IsPositive,
   IsString,
   ValidateNested,
@@ -22,5 +22,9 @@ export class RequestAttestationsDto {
 
   @ValidateNested()
   requestTx: RawTransactionDto
+
+  @IsOptional()
+  @ValidateNested()
+  approveTx?: RawTransactionDto
 }
 

--- a/apps/onboarding/src/subsidy/subsidy.service.spec.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.spec.ts
@@ -56,13 +56,6 @@ describe('SubsidyService', () => {
     stableToken = await contractKit.contracts.getStableToken()
     walletService = testingModule.get(WalletService)
     service = testingModule.get(SubsidyService)
-
-    // @ts-ignore
-    service.contractKit = contractKit
-    // @ts-ignore
-    service.walletService = walletService
-    // @ts-ignore
-    service.txParserService = testingModule.get(TxParserService)
   })
 
   beforeEach(() => {

--- a/apps/onboarding/src/subsidy/subsidy.service.spec.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.spec.ts
@@ -1,100 +1,259 @@
-import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
+import { BlockchainModule, ContractsModule } from '@app/blockchain'
+import { WEB3_PROVIDER } from '@app/blockchain/blockchain.providers'
+import { NodeProviderType } from '@app/blockchain/config/node.config'
 import { RequestAttestationsDto } from '@app/onboarding/dto/RequestAttestationsDto'
+import { Session } from '@app/onboarding/session/session.entity'
 import { SubsidyService } from '@app/onboarding/subsidy/subsidy.service'
+import { buildMockWeb3Provider } from '@app/onboarding/utils/testing/mock-web3-provider'
 import { TxParserService } from '@app/onboarding/wallet/tx-parser.service'
 import { WalletService } from '@app/onboarding/wallet/wallet.service'
+import { Err, Ok, Result, RootError, Signature } from '@celo/base'
 import { ContractKit } from '@celo/contractkit'
-import { WrapperCache } from '@celo/contractkit/lib/contract-cache'
 import { AttestationsWrapper } from '@celo/contractkit/lib/wrappers/Attestations'
+import { RawTransaction, toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { StableTokenWrapper } from '@celo/contractkit/lib/wrappers/StableTokenWrapper'
+import { InvalidBytecode } from '@celo/komencikit/lib/errors'
 import { Test, TestingModule } from '@nestjs/testing'
 import BigNumber from 'bignumber.js'
 import Web3 from 'web3'
+import { InvalidWallet, TxParseErrorTypes, WalletErrorType } from '../wallet/errors'
 
-jest.mock('@celo/contractkit')
-jest.mock('@celo/contractkit/lib/wrappers/Attestations')
-jest.mock('@celo/contractkit/lib/wrappers/StableTokenWrapper')
-jest.mock('@celo/contractkit/lib/contract-cache')
 jest.mock('@app/onboarding/wallet/wallet.service')
 
-// @ts-ignore
-const contractKit = new ContractKit()
-// @ts-ignore
-contractKit.contracts = new WrapperCache()
-const attestations = {
-  getAttestationStat: jest.fn(),
-  requireNAttestationsRequested: jest.fn(),
-  getAttestationFeeRequired: jest.fn(),
-}
-const stableToken = {
-  transfer: jest.fn()
-}
-
-
 describe('SubsidyService', () => {
-  const buildTestingModule = async (cfg: Partial<AppConfig>) => {
-    return Test.createTestingModule({
+  let testingModule: TestingModule
+  let service: SubsidyService
+  let contractKit: ContractKit
+  let attestations: AttestationsWrapper
+  let stableToken: StableTokenWrapper
+  let walletService: WalletService
+
+  beforeEach(async () => {
+    testingModule = await Test.createTestingModule({
+      imports: [
+        BlockchainModule.forRootAsync({
+          useFactory: () => {
+            return {
+              node: {
+                providerType: NodeProviderType.HTTP,
+                url: "not-a-node"
+              }
+            }
+          }
+        }),
+      ],
       providers: [
-        SubsidyService,
-        ContractKit,
-        WalletService,
         TxParserService,
-        {
-          provide: appConfig.KEY,
-          useValue: cfg
-        },
+        WalletService,
+        SubsidyService,
       ]
-    }).overrideProvider(ContractKit).useValue(contractKit).compile()
-  }
+    }).overrideProvider(WEB3_PROVIDER).useValue(
+      buildMockWeb3Provider(() => null)
+    ).compile()
+
+    contractKit = testingModule.get(ContractKit)
+    attestations = await contractKit.contracts.getAttestations()
+    stableToken = await contractKit.contracts.getStableToken()
+    walletService = testingModule.get(WalletService)
+    service = testingModule.get(SubsidyService)
+
+    // @ts-ignore
+    service.contractKit = contractKit
+    // @ts-ignore
+    service.walletService = walletService
+    // @ts-ignore
+    service.txParserService = testingModule.get(TxParserService)
+  })
 
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   const walletAddress = Web3.utils.randomHex(20)
+  const identifier = Web3.utils.randomHex(10)
+  const attestationsRequested = 3
 
-  describe('#buildTransactionBatch', () => {
-    const input: RequestAttestationsDto = {
-      identifier: Web3.utils.randomHex(10),
-      attestationsRequested: 3,
-      walletAddress,
-      requestTx: {
-        destination: walletAddress,
-        data: 'request',
-        value: "0",
-      },
+  let input: RequestAttestationsDto
+  let requestMetaTx: RawTransaction
+  let approveMetaTx: RawTransaction
+  let otherMetaTx: RawTransaction
+  let otherTx: RawTransaction
+
+  beforeEach(async () => {
+    const wallet = await contractKit.contracts.getMetaTransactionWallet(walletAddress)
+    const requestTx = await attestations.request(identifier, attestationsRequested)
+    const approveTx = stableToken.approve(attestations.address, 10)
+    const transferTx = stableToken.transfer(attestations.address, 10)
+    const sig: Signature = {v: 0, r: "0x0", s: "0x0"}
+
+    requestMetaTx = toRawTransaction(wallet.executeMetaTransaction(requestTx.txo, sig).txo)
+    approveMetaTx = toRawTransaction(wallet.executeMetaTransaction( approveTx.txo, sig).txo)
+    otherMetaTx = toRawTransaction(wallet.executeMetaTransaction(transferTx.txo, sig).txo)
+    otherTx = toRawTransaction(transferTx.txo)
+  })
+
+  describe('#isValid', () => {
+    const session = new Session()
+
+    function expectError<
+      TResult,
+      TError extends RootError<any>
+    >(result: Result<TResult, TError>, type: any) {
+      expect(result.ok).toBe(false)
+      if (result.ok === false) {
+        expect(result.error.errorType).toBe(type)
+      }
     }
 
-    let getAttestationStat: jest.SpyInstance
-    let requireNAttestations: jest.SpyInstance
-    let getAttestationFee: jest.SpyInstance
-    let transfer : jest.SpyInstance
-    const currentAttestations = 3
+    function expectSuccess<
+      TResult,
+      TError extends RootError<any>
+    >(result: Result<TResult, TError>) {
+      expect(result.ok).toBe(true)
+    }
 
-    beforeEach(() => {
-      jest.spyOn(contractKit.contracts, 'getAttestations').mockResolvedValue(attestations as any)
-      jest.spyOn(contractKit.contracts, 'getStableToken').mockResolvedValue(stableToken as any)
-      getAttestationStat = jest.spyOn(
-        attestations,
-        'getAttestationStat'
-      ).mockResolvedValue({
-        total: currentAttestations,
-        completed: 2
-      })
-
-      requireNAttestations = jest.spyOn(
-        attestations,
-        'requireNAttestationsRequested'
-      ).mockImplementation((identifier, account, count): any => {
-        return {
-          txo: {
-            destination: 'attestations',
-            data: { identifier, account, count },
-            value: "0"
-          }
+    describe('with an invalid wallet', () => {
+      beforeEach(() => {
+        const err = new InvalidWallet(new InvalidBytecode(walletAddress))
+        jest.spyOn(walletService, 'isValidWallet').mockReturnValue(Promise.resolve(Err(err)))
+        input = {
+          identifier,
+          attestationsRequested,
+          walletAddress,
+          requestTx: requestMetaTx,
         }
       })
 
+      it('returns an InvalidWallet error', async () => {
+        expectError(
+          await service.isValid(input, session),
+          WalletErrorType.InvalidWallet
+        )
+      })
+    })
+
+    describe('with a valid wallet', () => {
+      beforeEach(() => {
+        jest.spyOn(walletService, 'isValidWallet').mockReturnValue(Promise.resolve(Ok(true)))
+      })
+
+      describe('with only requestTx', () => {
+        describe('which is invalid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: otherMetaTx,
+            }
+          })
+
+          it('returns an TransactionNotAllowed error', async () => {
+            expectError(
+              await service.isValid(input, session),
+              TxParseErrorTypes.TransactionNotAllowed
+            )
+          })
+        })
+
+        describe('which is valid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: requestMetaTx,
+            }
+          })
+
+          it('is true', async () => {
+            expectSuccess(await service.isValid(input, session))
+          })
+        })
+      })
+
+      describe('with both requestTx and approveTx', () => {
+        describe('and both valid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: requestMetaTx,
+              approveTx: approveMetaTx
+            }
+          })
+
+          it('is true', async () => {
+            expectSuccess(await service.isValid(input, session))
+          })
+        })
+
+        describe('but both are invalid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: otherMetaTx,
+              approveTx: otherMetaTx,
+            }
+          })
+
+          it('returns an TransactionNotAllowed error', async () => {
+            expectError(
+              await service.isValid(input, session),
+              TxParseErrorTypes.TransactionNotAllowed
+            )
+          })
+        })
+
+        describe('but approveTx invalid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: requestMetaTx,
+              approveTx: otherMetaTx,
+            }
+          })
+
+          it('returns an TransactionNotAllowed error', async () => {
+            expectError(
+              await service.isValid(input, session),
+              TxParseErrorTypes.TransactionNotAllowed
+            )
+          })
+        })
+
+        describe('but requestTx invalid', () => {
+          beforeEach(() => {
+            input = {
+              identifier,
+              attestationsRequested,
+              walletAddress,
+              requestTx: otherMetaTx,
+              approveTx: approveMetaTx
+            }
+          })
+
+          it('returns an TransactionNotAllowed error', async () => {
+            expectError(
+              await service.isValid(input, session),
+              TxParseErrorTypes.TransactionNotAllowed
+            )
+          })
+        })
+      })
+    })
+  })
+
+  describe('#buildTransactionBatch', () => {
+    let getAttestationFee: jest.SpyInstance
+    let transfer : jest.SpyInstance
+
+    beforeEach(() => {
       getAttestationFee = jest.spyOn(
         attestations,
         'getAttestationFeeRequired'
@@ -116,50 +275,43 @@ describe('SubsidyService', () => {
       })
     })
 
-    describe('when guards are active', () => {
-      let service: SubsidyService
 
-      beforeEach(async () => {
-        const module = await buildTestingModule({useAttestationGuards: true})
-        service = module.get<SubsidyService>(SubsidyService)
+    describe("without approveTx", () => {
+      beforeEach(() => {
+        input = {
+          identifier,
+          attestationsRequested,
+          walletAddress,
+          requestTx: requestMetaTx,
+        }
       })
 
-      it('outputs 5 transactions', async () => {
+      it('outputs 2 transactions', async () => {
         const batch = await service.buildTransactionBatch(input)
-        expect(batch.length).toEqual(4)
+        expect(batch.length).toEqual(2)
 
-        expect(getAttestationStat).toHaveBeenCalled()
         expect(transfer).toHaveBeenCalledWith(input.walletAddress, new BigNumber(100 * input.attestationsRequested).toFixed())
         expect(getAttestationFee).toHaveBeenCalledWith(input.attestationsRequested)
-        expect(requireNAttestations).toHaveBeenCalledWith(
-          input.identifier,
-          input.walletAddress,
-          currentAttestations
-        )
-        expect(requireNAttestations).toHaveBeenCalledWith(
-          input.identifier,
-          input.walletAddress,
-          currentAttestations + input.attestationsRequested
-        )
       })
     })
 
-    describe('when guards are not active', () => {
-      let service: SubsidyService
-
-      beforeEach(async () => {
-        const module = await buildTestingModule({useAttestationGuards: false})
-        service = module.get<SubsidyService>(SubsidyService)
+    describe("with approveTx", () => {
+      beforeEach(() => {
+        input = {
+          identifier,
+          attestationsRequested,
+          walletAddress,
+          requestTx: requestMetaTx,
+          approveTx: approveMetaTx,
+        }
       })
 
       it('outputs 3 transactions', async () => {
         const batch = await service.buildTransactionBatch(input)
-        expect(batch.length).toEqual(2)
+        expect(batch.length).toEqual(3)
 
-        expect(getAttestationStat).not.toHaveBeenCalled()
         expect(transfer).toHaveBeenCalledWith(input.walletAddress, new BigNumber(100 * input.attestationsRequested).toFixed())
         expect(getAttestationFee).toHaveBeenCalledWith(input.attestationsRequested)
-        expect(requireNAttestations).not.toHaveBeenCalled()
       })
     })
   })

--- a/apps/onboarding/src/subsidy/subsidy.service.ts
+++ b/apps/onboarding/src/subsidy/subsidy.service.ts
@@ -6,9 +6,11 @@ import { WalletService } from '@app/onboarding/wallet/wallet.service'
 import { Ok, Result } from '@celo/base/lib/result'
 import { CeloContract, ContractKit } from '@celo/contractkit'
 import { RawTransaction, toRawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
+import { Injectable } from '@nestjs/common'
 import { RawTransactionDto } from 'apps/relayer/src/dto/RawTransactionDto'
 import { Session } from '../session/session.entity'
 
+@Injectable()
 export class SubsidyService {
   constructor(
     private readonly walletService: WalletService,

--- a/apps/onboarding/src/wallet/errors.ts
+++ b/apps/onboarding/src/wallet/errors.ts
@@ -30,7 +30,7 @@ export class InvalidWallet extends ApiError<WalletErrorType> {
   metadataProps = ['reason']
 
   constructor(readonly reason: WalletValidationError) {
-    super(WalletErrorType.InvalidImplementation)
+    super(WalletErrorType.InvalidWallet)
     this.message = "Invalid wallet"
   }
 }


### PR DESCRIPTION
### Overview

In order for a successful subsidised attestations request we need three contract calls to pass:

1. `transfer` of `fee` from fund to user's meta transaction wallet
2. Meta transaction wallet `approve` the Attestations contract to transfer `fee`
3. Meta transaction wallet `request` attestations.

In the first version of Valora to go out we opted for doing `approve` independently as a transaction and `transfer & request`  as another transaction. This made it easier to comply with the existing verifications flow, but it adds another chain round-trip that can be avoided.

In this PR we extend the `SubsidyService` so that it can be passed in both the `approve` and `request` meta transactions, with `approve` being optional (for backward compatibility), and bundling both in the batched meta transaction.

#### Drive-by changes

Because of some changes in `celo-monorepo` at the moment AttestationsWrapper doesn't have the `requireNAttestationsRequested` method, which means that if we actually toggle that config on it will not work, which seams a bit dangerous. I decided to remove all references and we can bring that back when we implement that as a feature.

The above was brought to light after refactoring the specs to be more robust.