### PR TITLE
Send rewards using the relayer and add retries

### DIFF
--- a/apps/rewards/src/app.module.ts
+++ b/apps/rewards/src/app.module.ts
@@ -1,22 +1,17 @@
 import { BlockchainModule } from '@app/blockchain'
 import { NodeProviderType } from '@app/blockchain/config/node.config'
 import { KomenciLoggerModule } from '@app/komenci-logger'
-import { ApiErrorFilter } from '@app/komenci-logger/filters/api-error.filter'
+import { relayerConfig } from '@app/onboarding/config/relayer.config'
 import { loggerConfigFactory } from '@app/onboarding/logger-config.factory'
 import { NetworkConfig, networkConfig } from '@app/utils/config/network.config'
 import { HttpModule, Module } from '@nestjs/common'
 import { ConfigModule, ConfigService } from '@nestjs/config'
-import { APP_FILTER } from '@nestjs/core'
 import { ScheduleModule } from '@nestjs/schedule'
 import { TypeOrmModule } from '@nestjs/typeorm'
 import { InviteRewardModule } from 'apps/rewards/src/invite/inviteReward.module'
-import { InviteRewardService } from 'apps/rewards/src/invite/inviteReward.service'
 import { AttestationModule } from './attestation/attestation.module'
-import { AttestationService } from './attestation/attestation.service'
-import { NotifiedBlockService } from './blocks/notifiedBlock.service'
 import { appConfig } from './config/app.config'
 import { DatabaseConfig, databaseConfig } from './config/database.config'
-import { EventService } from './event/eventService.service'
 
 @Module({
   controllers: [],
@@ -26,7 +21,7 @@ import { EventService } from './event/eventService.service'
     ScheduleModule.forRoot(),
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, databaseConfig, networkConfig],
+      load: [appConfig, databaseConfig, networkConfig, relayerConfig],
       envFilePath: ['apps/rewards/.env.local', 'apps/rewards/.env']
     }),
     KomenciLoggerModule.forRootAsync({
@@ -53,15 +48,6 @@ import { EventService } from './event/eventService.service'
       }
     })
   ],
-  providers: [
-    InviteRewardService,
-    AttestationService,
-    NotifiedBlockService,
-    EventService,
-    {
-      provide: APP_FILTER,
-      useClass: ApiErrorFilter
-    }
-  ]
+  providers: []
 })
 export class AppModule {}

--- a/apps/rewards/src/attestation/attestation.service.ts
+++ b/apps/rewards/src/attestation/attestation.service.ts
@@ -20,7 +20,7 @@ export class AttestationService {
     private readonly logger: KomenciLoggerService
   ) {}
 
-  @Cron(CronExpression.EVERY_10_SECONDS)
+  @Cron(CronExpression.EVERY_30_SECONDS)
   async fetchAttestations() {
     await this.eventService.runEventProcessingPolling(
       NOTIFIED_BLOCK_KEY,

--- a/apps/rewards/src/config/relayer.config.ts
+++ b/apps/rewards/src/config/relayer.config.ts
@@ -1,0 +1,12 @@
+import { registerAs } from '@nestjs/config'
+import { TcpClientOptions, Transport } from '@nestjs/microservices'
+
+export const relayerConfig = registerAs<() => TcpClientOptions>('relayer', () => ({
+  transport: Transport.TCP,
+  options: {
+    host: process.env.RELAYER_HOST,
+    port: parseInt(process.env.RELAYER_PORT, 10)
+  }
+}))
+
+export type RelayerConfig = TcpClientOptions

--- a/apps/rewards/src/invite/inviteReward.entity.ts
+++ b/apps/rewards/src/invite/inviteReward.entity.ts
@@ -2,8 +2,10 @@ import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 
 export enum RewardStatus {
   Created = 'Created',
-  Sent = 'Sent',
-  Failed = 'Failed'
+  Submitted = 'Submitted',
+  Completed = 'Completed',
+  Failed = 'Failed',
+  DeadLettered = 'DeadLettered'
 }
 
 @Entity()

--- a/apps/rewards/src/invite/rewardSender.service.ts
+++ b/apps/rewards/src/invite/rewardSender.service.ts
@@ -1,0 +1,123 @@
+import { KomenciLoggerService } from '@app/komenci-logger'
+import { ContractKit } from '@celo/contractkit'
+import { Inject, Injectable } from '@nestjs/common'
+import { RelayerProxyService } from '../relayer/relayer_proxy.service'
+import { InviteReward, RewardStatus } from './inviteReward.entity'
+import { Cron, CronExpression } from '@nestjs/schedule'
+import { InviteRewardRepository } from './inviteReward.repository'
+import { appConfig, AppConfig } from '../config/app.config'
+import { EntityManager, In, LessThan, Raw, Repository } from 'typeorm'
+
+interface WatchedInvite {
+  inviteId: string
+  txHash: string
+  sentAt: number
+  markAsDeadLetterIfFailed: boolean
+}
+
+@Injectable()
+export class RewardSenderService {
+  watchedInvites: Set<WatchedInvite>
+
+  constructor(
+    private readonly inviteRewardRepository: InviteRewardRepository,
+    private readonly relayerProxyService: RelayerProxyService,
+    @Inject(appConfig.KEY)
+    private readonly appCfg: AppConfig,
+    private readonly contractKit: ContractKit,
+    private readonly logger: KomenciLoggerService
+  ) {
+    this.watchedInvites = new Set()
+  }
+
+  @Cron(CronExpression.EVERY_SECOND)
+  async checkWatchedInvites() {
+    await Promise.all(
+      [...this.watchedInvites].map(async invite => {
+        const tx = await this.contractKit.web3.eth.getTransaction(invite.txHash)
+        if (tx.blockHash) {
+          await this.inviteRewardRepository.update(invite.inviteId, {
+            state: RewardStatus.Completed
+          })
+          this.watchedInvites.delete(invite)
+        } else if (
+          Date.now() - invite.sentAt >
+          this.appCfg.transactionTimeoutMs
+        ) {
+          await this.inviteRewardRepository.update(invite.inviteId, {
+            state: invite.markAsDeadLetterIfFailed
+              ? RewardStatus.DeadLettered
+              : RewardStatus.Failed
+          })
+          this.watchedInvites.delete(invite)
+        }
+      })
+    )
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async checkFailedInvites() {
+    this.inviteRewardRepository.manager.transaction(
+      async (entityManager: EntityManager) => {
+        const repository = entityManager.getRepository<InviteReward>(
+          'invite_reward'
+        )
+        const invites = await repository
+          .createQueryBuilder()
+          .setLock('pessimistic_read')
+          .where({
+            state: In([RewardStatus.Submitted, RewardStatus.Failed]),
+            createdAt: Raw(
+              alias =>
+                `${alias} <= current_timestamp - (30 ||' minutes')::interval`
+            )
+          })
+          .getMany()
+        await Promise.all(
+          invites.map(invite => this.sendInviteReward(invite, true, repository))
+        )
+      }
+    )
+  }
+
+  async sendInviteReward(
+    invite: InviteReward,
+    isRetry: boolean = false,
+    repository: Repository<InviteReward> = this.inviteRewardRepository
+  ) {
+    const celoToken = await this.contractKit.contracts.getGoldToken()
+    const tx = await celoToken.transfer(invite.inviter, 1)
+
+    const resp = await this.relayerProxyService.submitTransaction(
+      {
+        transaction: {
+          destination: tx.txo._parent.options.address,
+          value: '0',
+          data: tx.txo.encodeABI()
+        }
+      },
+      invite.id
+    )
+    if (resp.ok === false) {
+      this.logger.error(
+        `Error sending reward for invite ${invite.id}: ${resp.error}`
+      )
+      await repository.update(invite.id, {
+        state: isRetry ? RewardStatus.DeadLettered : RewardStatus.Failed
+      })
+    } else {
+      const txHash = resp.result.payload
+      this.logger.log(`Reward submitted for invite ${invite.id}: ${txHash}`)
+      await repository.update(invite.id, {
+        state: RewardStatus.Submitted,
+        rewardTxHash: txHash
+      })
+      this.watchedInvites.add({
+        inviteId: invite.id,
+        txHash,
+        sentAt: Date.now(),
+        markAsDeadLetterIfFailed: isRetry
+      })
+    }
+  }
+}

--- a/apps/rewards/src/relayer/relayer_proxy.service.ts
+++ b/apps/rewards/src/relayer/relayer_proxy.service.ts
@@ -1,0 +1,120 @@
+import { MetadataError } from '@app/komenci-logger/errors'
+import { appConfig, AppConfig } from '@app/onboarding/config/app.config'
+import { Session } from '@app/onboarding/session/session.entity'
+import { Err, Ok, Result } from '@celo/base/lib/result'
+import { Inject, Injectable, Scope } from '@nestjs/common'
+import { REQUEST } from '@nestjs/core'
+import { ClientProxy } from '@nestjs/microservices'
+import { RelayerCmd, RelayerResponse } from 'apps/relayer/src/app.controller'
+import { GetPhoneNumberSignatureDto } from 'apps/relayer/src/dto/GetPhoneNumberSignatureDto'
+import { RelayerCommandDto } from 'apps/relayer/src/dto/RelayerCommandDto'
+import { SignPersonalMessageDto } from 'apps/relayer/src/dto/SignPersonalMessageDto'
+import { SubmitTransactionBatchDto } from 'apps/relayer/src/dto/SubmitTransactionBatchDto'
+import { SubmitTransactionDto } from 'apps/relayer/src/dto/SubmitTransactionDto'
+import { isRight } from 'fp-ts/Either'
+import * as t from 'io-ts'
+import { of, race } from 'rxjs'
+import { catchError, delay, map } from 'rxjs/operators'
+
+export enum RelayerErrorTypes {
+  RelayerTimeout = 'RelayerTimeout',
+  RelayerCommunicationError = 'RelayerCommunicationError',
+  RelayerInternalError = 'RelayerInternalError'
+}
+
+const InternalErrorPayload = t.type({
+  errorType: t.string,
+  message: t.string,
+  metadata: t.unknown
+})
+
+type InternalErrorPayload = t.TypeOf<typeof InternalErrorPayload>
+
+class RelayerTimeout extends MetadataError<RelayerErrorTypes.RelayerTimeout> {
+  metadataProps = ['cmd']
+
+  constructor(readonly cmd: string) {
+    super(RelayerErrorTypes.RelayerTimeout)
+  }
+}
+
+class RelayerCommunicationError extends MetadataError<
+  RelayerErrorTypes.RelayerCommunicationError
+> {
+  metadataProps = ['cmd']
+
+  constructor(readonly message: string, readonly cmd: string) {
+    super(RelayerErrorTypes.RelayerCommunicationError)
+  }
+}
+
+class RelayerInternalError extends MetadataError<
+  RelayerErrorTypes.RelayerInternalError
+> {
+  metadataProps = ['internalError']
+
+  constructor(readonly internalError: InternalErrorPayload) {
+    super(RelayerErrorTypes.RelayerInternalError)
+    this.message = `Relayer encountered an error`
+  }
+}
+
+type RelayerError =
+  | RelayerTimeout
+  | RelayerCommunicationError
+  | RelayerInternalError
+type RelayerResult<TResp> = Result<RelayerResponse<TResp>, RelayerError>
+
+@Injectable()
+export class RelayerProxyService {
+  constructor(
+    @Inject('RELAYER_SERVICE') private client: ClientProxy,
+    @Inject(appConfig.KEY) private cfg: AppConfig
+  ) {}
+
+  async submitTransaction(
+    input: SubmitTransactionDto,
+    traceId: string
+  ): Promise<RelayerResult<string>> {
+    return this.execute(RelayerCmd.SubmitTransaction, input, traceId)
+  }
+
+  async submitTransactionBatch(
+    input: SubmitTransactionBatchDto,
+    traceId: string
+  ): Promise<RelayerResult<string>> {
+    return this.execute(RelayerCmd.SubmitTransactionBatch, input, traceId)
+  }
+
+  private execute<TResp, TInput extends RelayerCommandDto>(
+    cmd: RelayerCmd,
+    input: TInput,
+    traceId: string
+  ): Promise<RelayerResult<TResp>> {
+    const inputWithContext: TInput = {
+      ...input,
+      context: {
+        traceId,
+        labels: []
+      }
+    }
+
+    return race<RelayerResult<TResp>>(
+      of('timeout').pipe(
+        delay(this.cfg.relayerRpcTimeoutMs),
+        map(_ => Err(new RelayerTimeout(cmd)))
+      ),
+      this.client.send<RelayerResponse<TResp>>({ cmd }, inputWithContext).pipe(
+        map(resp => Ok(resp)),
+        catchError(err => {
+          const res = InternalErrorPayload.decode(err)
+          if (isRight(res)) {
+            return of(Err(new RelayerInternalError(res.right)))
+          } else {
+            return of(Err(new RelayerCommunicationError(err.message, cmd)))
+          }
+        })
+      )
+    ).toPromise()
+  }
+}


### PR DESCRIPTION

- When a reward must be sent, we now send it using the relayer. Created a `RewardSenderService` for this. Additional configuration is needed to use a specific account/HSM for distribution.
- We're not using the same relayer proxy file as the onboarding because the onboarding one has a per request scope. There are no requests here so it was not working properly with that. We still need to figure out a way to create new connections per reward sending because right now we are holding a single connection to a single relayer.
- We're missing some tests for the new service.