### PR TITLE
Use batch web3 batch requests for querying watched transaction status

### DIFF
--- a/scripts/libs.build.sh
+++ b/scripts/libs.build.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-yarn lerna run build --scope @komenci/core
-yarn lerna run build --scope @komenci/logger
-yarn lerna run build --scope @komenci/throttler
-yarn lerna run build --scope @komenci/kit
-yarn lerna run build --scope @komenci/blockchain
+yarn lerna run build --scope @komenci/core \
+                     --scope @komenci/logger \
+                     --scope @komenci/throttler \
+                     --scope @komenci/kit \
+                     --scope @komenci/blockchain \
+                     --scope @komenci/analytics

--- a/scripts/libs.run.sh
+++ b/scripts/libs.run.sh
@@ -6,4 +6,5 @@ yarn lerna run --parallel \
                --scope @komenci/throttler \
                --scope @komenci/kit \
                --scope @komenci/blockchain \
+               --scope @komenci/analytics \
                $@


### PR DESCRIPTION
### Problem

In production we're seeing an issue pop up on the relayers every 3-4 days.

It's show in the logs as:
```javascript
{
  jsonPayload: {
    trace: ""
    @type: "type.googleapis.com/google.devtools.clouderrorreporting.v1beta1.ReportedErrorEvent"
    serviceContext: {2}
    message: {
      errno: "ECONNRESET"
      code: "ECONNRESET"
      syscall: "read"
    }
    context: "Server"
  }
}
```

It's not clear how to debug, it's effectively impossible to reproduce locally and it's only mitigated by restarting the relayer pods. It's unclear if the restart works because it fixes something on the relayer side or because it causes the relayer to connect to new nodes - the Forno load-balancer having session affinity.

### Exploration

The error message isn't great and lacks a stack trace, but as far as I can tell the trace would originate from internals so it wouldn't be truly helpful.
There's [this thread](https://github.com/openethereum/parity-ethereum/issues/9573) that seams relevant but doesn't have much in the way of resolution. Especially because it's about `parity` and we use `geth` it's also pretty old and makes it sound like the issues lies more with the `nodes` rather than the client who's consuming. 

I've found some older issues around `nodejs` having issues with sockets that are closed out of order but that seams old - tho we are running `nodejs-10` and some reports mention resolution to this issue when upgrading node.

Nonetheless this issue cropping up seams to be a function of _how many and how frequently_ the relayer is making requests to the node, and our relayer currently dose up to two HTTP requests per watched transaction per refresh cycle. This adds up to a lot over time. In order to try mitigating this, I've refactored the transaction service to make use of the `BatchRequest` functionality in `web3js` which batches multiple RPC calls into a single HTTP request. This way it reduces the number of request to 2 per refresh cycle, one for all transactions and one for all receipts.

Another direction I would like to explore is removing session affinity between backend Komenci services and Forno. For individual clients, like Valora, it makes sense to have session affinity. But for read-heavy backend services it might make sense to distribute requests across nodes.