### PR TITLE
Add cEUR support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM node:10 as builder
 
-ARG KOMENCI_VERSION
-ENV KOMENCI_VERSION=$KOMENCI_VERSION
-
 RUN mkdir /komenci
 WORKDIR /komenci
 
@@ -13,6 +10,9 @@ RUN SKIPPOSTINSTALL=1 yarn
 RUN yarn build
 
 FROM node:10 as release
+
+ARG KOMENCI_VERSION
+ENV KOMENCI_VERSION=$KOMENCI_VERSION
 
 RUN mkdir /komenci
 WORKDIR /komenci

--- a/packages/apps/api/src/wallet/tx-parser.service.ts
+++ b/packages/apps/api/src/wallet/tx-parser.service.ts
@@ -1,5 +1,5 @@
 import { Err, normalizeAddress, Ok, Result } from '@celo/base'
-import { CeloContract, ContractKit } from '@celo/contractkit'
+import { CeloContract, ContractKit, StableToken } from '@celo/contractkit'
 import { BaseWrapper } from '@celo/contractkit/lib/wrappers/BaseWrapper'
 import { MetaTransactionWalletWrapper, RawTransaction } from '@celo/contractkit/lib/wrappers/MetaTransactionWallet'
 import { extractMethodId, normalizeMethodId } from '@komenci/core'
@@ -32,6 +32,10 @@ export class TxParserService implements OnModuleInit {
     ).addContract(
       CeloContract.StableToken,
       await this.contractKit.contracts.getStableToken(),
+      ["approve", "transfer"]
+    ).addContract(
+      CeloContract.StableTokenEUR,
+      await this.contractKit.contracts.getStableToken(StableToken.cEUR),
       ["approve", "transfer"]
     ).addContract(
       CeloContract.Escrow,

--- a/packages/apps/rewards/src/invite/inviteReward.service.ts
+++ b/packages/apps/rewards/src/invite/inviteReward.service.ts
@@ -30,6 +30,7 @@ export class InviteRewardService {
   isRunning = false
   komenciAddresses = []
   cUsdTokenAddress = null
+  cEurTokenAddress = null
 
   constructor(
     private readonly inviteRewardRepository: InviteRewardRepository,
@@ -66,6 +67,9 @@ export class InviteRewardService {
     this.cUsdTokenAddress = (
       await this.contractKit.registry.addressFor(CeloContract.StableToken)
     ).toLowerCase()
+    this.cEurTokenAddress = (
+      await this.contractKit.registry.addressFor(CeloContract.StableTokenEUR)
+    ).toLowerCase()
 
     await this.eventService.runEventProcessingPolling(
       NOTIFIED_BLOCK_KEY,
@@ -91,13 +95,13 @@ export class InviteRewardService {
     } = withdrawalEvent
 
     const inviter = to.toLowerCase()
-    if (this.cUsdTokenAddress !== token.toLowerCase()) {
+    if (![this.cUsdTokenAddress, this.cEurTokenAddress].includes(token.toLowerCase())) {
       this.analytics.trackEvent(EventType.InviteNotRewarded, {
         txHash: transactionHash,
         inviter,
         invitee: null,
         paymentId,
-        reason: InviteNotRewardedReason.NotCusdInvite
+        reason: InviteNotRewardedReason.NotStableTokenInvite
       })
       return
     }

--- a/packages/libs/logger/src/events.ts
+++ b/packages/libs/logger/src/events.ts
@@ -174,7 +174,7 @@ export type SessionTxEvent = SessionEvent & {
 }
 
 export enum InviteNotRewardedReason {
-  NotCusdInvite = 'NotCusdInvite',
+  NotStableTokenInvite = 'NotStableTokenInvite',
   NotKomenciRedeem = 'NotKomenciRedeem',
   NoInviteeFound = 'NoInviteeFound',
   InviterNotVerified = 'InviterNotVerified',


### PR DESCRIPTION
Two changes in this PR:

- Add to the allowlist interactions to the cEUR contract in the onboarding service so that users can redeem invites they received in cEUR. Right now it's failing because only cUSD transfers are allowed.
- When a user redeems an invite made with cEUR, allow the inviter to be rewarded.