### PR TITLE
Add reward sending in cEUR

### DIFF
--- a/packages/apps/cli/.gitignore
+++ b/packages/apps/cli/.gitignore
@@ -1,5 +1,6 @@
 dist
 node_modules
 coverage
+.env
 .env.local
 .env.test

--- a/packages/apps/rewards/src/invite/inviteReward.entity.ts
+++ b/packages/apps/rewards/src/invite/inviteReward.entity.ts
@@ -1,3 +1,4 @@
+import { StableToken } from '@celo/contractkit'
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 
 export enum RewardStatus {
@@ -33,6 +34,9 @@ export class InviteReward {
 
   @Column({ unique: true })
   rewardTxHash: string
+
+  @Column()
+  inviteToken: StableToken
 
   @Column('timestamp')
   createdAt: string

--- a/packages/apps/rewards/src/invite/rewardSender.service.ts
+++ b/packages/apps/rewards/src/invite/rewardSender.service.ts
@@ -212,10 +212,8 @@ export class RewardSenderService {
     isRetry: boolean = false,
     repository: Repository<InviteReward> = this.inviteRewardRepository
   ) {
-    const cUsdToken = await this.contractKit.contracts.getStableToken(
-      StableToken.cUSD
-    )
-    const tx = await cUsdToken.transfer(
+    const stableToken = await this.contractKit.contracts.getStableToken(invite.inviteToken)
+    const tx = await stableToken.transfer(
       invite.inviter,
       new BigNumber(this.appCfg.inviteRewardAmountInCusd)
         .multipliedBy(WEI_PER_UNIT)

--- a/packages/apps/rewards/src/migrations/1633031131296-AddInviteTokenToInviteReward.ts
+++ b/packages/apps/rewards/src/migrations/1633031131296-AddInviteTokenToInviteReward.ts
@@ -1,0 +1,12 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class AddInviteTokenToInviteReward1633031131296 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE invite_reward ADD COLUMN "inviteToken" varchar(10)`); 
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}


### PR DESCRIPTION
We were already rewarding invites made with cEUR but we were sending the reward in cUSD. The changes in this PR make it so the reward is sent out in the same token that the invite was.

