### PR TITLE
Querying the identifier also returns the unblinded signature

### DIFF
--- a/packages/libs/komencikit/package.json
+++ b/packages/libs/komencikit/package.json
@@ -27,7 +27,7 @@
     "@celo/base": "1.2.0",
     "@celo/connect": "1.2.0",
     "@celo/contractkit": "1.2.0",
-    "@celo/identity": "1.2.0",
+    "@celo/identity": "1.5.3-dev",
     "@celo/utils": "1.2.0",
     "cross-fetch": "3.0.6",
     "fp-ts": "2.8.4",

--- a/packages/libs/komencikit/src/actions.ts
+++ b/packages/libs/komencikit/src/actions.ts
@@ -110,6 +110,7 @@ export type GetCombinedSignatureResp = t.TypeOf<typeof GetCombinedSignatureResp>
 export const GetDistributedBlindedPepperResp = t.type({
   identifier: t.string,
   pepper: t.string,
+  unblindedSig: t.string
 })
 
 export type GetDistributedBlindedPepperResp = t.TypeOf<typeof GetDistributedBlindedPepperResp>

--- a/packages/libs/komencikit/src/kit.ts
+++ b/packages/libs/komencikit/src/kit.ts
@@ -187,6 +187,7 @@ export class KomenciKit {
       return Ok({
         identifier: phoneNumberHashDetails.phoneHash,
         pepper: phoneNumberHashDetails.pepper,
+        unblindedSig: phoneNumberHashDetails.unblindedSignature
       })
     }
 


### PR DESCRIPTION
This PR is part of https://github.com/celo-org/celo-monorepo/issues/9235, and is meant to make `komencikit` compatible with the changes in https://github.com/celo-org/celo-monorepo/pull/9393. The  unblinded signature is returned in `getDistributedBlindedPepper` so that it can be passed to the attestation service for pepper verification.